### PR TITLE
chore: replace external actions with offical github script action

### DIFF
--- a/.github/workflows/release_please.yaml
+++ b/.github/workflows/release_please.yaml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: GoogleCloudPlatform/release-please-action@v3.1.2
         id: release
         with:
           # use the CI token to pretend not to be a action

--- a/.github/workflows/semantic-commits.yaml
+++ b/.github/workflows/semantic-commits.yaml
@@ -14,8 +14,27 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: deepakputhraya/action-pr-title@master
+      - uses: actions/github-script@v6
+        env:
+          # Ensure pull request titles match the Conventional Commits specification
+          # https://www.conventionalcommits.org/en/v1.0.0/
+          regex: '^(feat|fix|chore|ci|refactor|docs)(\(.*\))?!?:'
         with:
-          # Ensure pull request titles match the Conventional Commits specification https://www.conventionalcommits.org/en/v1.0.0/
-          regex: '^(feat|fix|chore|ci|refactor|test|docs)(\(.*\))?!?:'
+          script: |
+            if (context.eventName != "pull_request") {
+              core.setFailed("This action only works on pull_request events");
+              return;
+            }
+            core.info(`Checking pull request title with regex: ${process.env.regex}`);
+            const regex = RegExp(process.env.regex);
+            const {data: pullRequest} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const title = pullRequest.title;
+            core.info(`Pull Request title: "${title}"`);
+            if (!regex.test(title)) {
+                core.setFailed(`Pull Request title "${title}" failed to pass match regex - ${regex}`);
+                return;
+            }

--- a/github/release-please.yaml
+++ b/github/release-please.yaml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: GoogleCloudPlatform/release-please-action@v3.1.2
         id: release
         with:
           # use the CI token to pretend not to be a action

--- a/github/semantic-commits.yaml
+++ b/github/semantic-commits.yaml
@@ -14,8 +14,27 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: deepakputhraya/action-pr-title@master
+      - uses: actions/github-script@v6
+        env:
+          # Ensure pull request titles match the Conventional Commits specification
+          # https://www.conventionalcommits.org/en/v1.0.0/
+          regex: '^(feat|fix|chore|ci|refactor|docs)(\(.*\))?!?:'
         with:
-          # Ensure pull request titles match the Conventional Commits specification https://www.conventionalcommits.org/en/v1.0.0/
-          regex: '^(feat|fix|chore|ci|refactor|test|docs)(\(.*\))?!?:'
+          script: |
+            if (context.eventName != "pull_request") {
+              core.setFailed("This action only works on pull_request events");
+              return;
+            }
+            core.info(`Checking pull request title with regex: ${process.env.regex}`);
+            const regex = RegExp(process.env.regex);
+            const {data: pullRequest} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const title = pullRequest.title;
+            core.info(`Pull Request title: "${title}"`);
+            if (!regex.test(title)) {
+                core.setFailed(`Pull Request title "${title}" failed to pass match regex - ${regex}`);
+                return;
+            }


### PR DESCRIPTION
Replace the convential commit action wituh a github script implementation. This is the _same_ implementation from the original action, but this ensures that we own the implementation and can not accidentally leak something by using an action `@main`

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>