### PR TITLE
feat: Remove archived template_file provider in favour of templatefile function

### DIFF
--- a/datahub/datahub.tf
+++ b/datahub/datahub.tf
@@ -81,6 +81,12 @@ resource "helm_release" "datahub" {
   max_history = 3
   create_namespace = true
     values = [
-        templatefile("${path.module}/helm-values.tpl", { UI_INGRESS_HOST = var.ui_ingress_host, API_INGRESS_HOST = var.api_ingress_host, INGRESS_CLASS  = var.ingress_class })
+        templatefile("${path.module}/helm-values.tpl",
+          {
+            UI_INGRESS_HOST = var.ui_ingress_host,
+            API_INGRESS_HOST = var.api_ingress_host,
+            INGRESS_CLASS  = var.ingress_class
+          }
+        )
     ]
 }


### PR DESCRIPTION
- Template File provider has been archived. Terraform has a `templatefile()` function that is part of Terraform core.
- Removing backend config. This is a module and backends are meant to be configured by module consumers. 
- Removing provider configs. Providers are also meant to be configured in module consumers
