### PR TITLE
feat(monitoring)!: bump kube-prometheus-stack to 83.4.3 and migrate to Gateway API

### DIFF
--- a/monitoring/assets/helm-values-monitoring.tpl
+++ b/monitoring/assets/helm-values-monitoring.tpl
@@ -3,6 +3,10 @@ coreDns:
 kubeDns:
   enabled: false
 
+# Top-level upgradeJob for CRDs
+upgradeJob:
+  enabled: true
+
 grafana:
   adminUser: ${GRAFANA_ADMIN_USER}
   adminPassword: ${GRAFANA_ADMIN_PASSWORD}
@@ -13,16 +17,16 @@ grafana:
       - ReadWriteOnce
     size: ${GRAFANA_PVC_SIZE}
   ingress:
-    enabled: true
-    ingressClassName: ${GRAFANA_INGRESS_CLASS_NAME}
-    annotations:
-      cert-manager.io/cluster-issuer: ${CERT_MANAGER_CLUSTER_ISSUER_NAME}
-    hosts:
-      - ${GRAFANA_HOST}
-    tls:
-     - secretName: ${GRAFANA_HOST}-tls-auto-generated
-       hosts:
-         - ${GRAFANA_HOST}
+    enabled: false
+  route:
+    main:
+      enabled: true
+      hostnames:
+        - ${GRAFANA_HOST}
+      parentRefs:
+        - name: ${GRAFANA_GATEWAY_NAME}
+          namespace: ${GRAFANA_GATEWAY_NAMESPACE}
+          sectionName: ${GRAFANA_GATEWAY_SECTION}
   resources:
    limits:
      cpu: 500m
@@ -60,16 +64,16 @@ defaultRules:
 
 alertmanager:
   ingress:
-    enabled: true
-    ingressClassName: ${ALERT_MANAGER_INGRESS_CLASS_NAME}
-    annotations:
-      cert-manager.io/cluster-issuer: ${CERT_MANAGER_CLUSTER_ISSUER_NAME}
-    hosts:
-      - ${ALERT_MANAGER_HOST}
-    tls:
-    - secretName: ${ALERT_MANAGER_HOST}-tls-auto-generated
-      hosts:
-      - ${ALERT_MANAGER_HOST}
+    enabled: false
+  route:
+    main:
+      enabled: true
+      hostnames:
+        - ${ALERT_MANAGER_HOST}
+      parentRefs:
+        - name: ${ALERT_MANAGER_GATEWAY_NAME}
+          namespace: ${ALERT_MANAGER_GATEWAY_NAMESPACE}
+          sectionName: ${ALERT_MANAGER_GATEWAY_SECTION}
   templateFiles:
   ## An example template:
     alert_silence_template.tmpl: |-

--- a/monitoring/assets/helm-values-monitoring.tpl
+++ b/monitoring/assets/helm-values-monitoring.tpl
@@ -183,476 +183,480 @@ alertmanager:
     templates:
     - '/etc/alertmanager/config/*.tmpl'
 
+# Corrected to a map for kube-prometheus-stack 83.x
 additionalPrometheusRulesMap:
-- groups:
-    - name: blackbox-exporter
-      rules:
-      - alert: HttpProbeFailed
-        annotations:
-          description: |-
-            Probe failed
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} probe failed.'
-          summary: Probe failed (instance {{ $labels.instance }})
-        expr: probe_success == 0
-        for: 5m
-        labels:
-          severity: error
-          job: blackbox-exporter
-      - alert: SlowPing
-        annotations:
-          description: |-
-            Blackbox ping took more than 2s
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} Ping took more than 2s.'
-          summary: Slow ping (instance {{ $labels.instance }})
-        expr: avg_over_time(probe_icmp_duration_seconds[1m]) > 2
-        for: 5m
-        labels:
-          severity: warning
-          job: blackbox-exporter
-      - alert: SlowProbe
-        annotations:
-          description: |-
-            Blackbox probe took more than 2s to complete
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} probe took more than 2s.'
-          summary: Slow probe (instance {{ $labels.instance }})
-        expr: avg_over_time(probe_duration_seconds[1m]) > 2
-        for: 5m
-        labels:
-          severity: warning
-          job: blackbox-exporter
-      - alert: HttpStatusCode
-        annotations:
-          description: |-
-            HTTP status code is not 200-399
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} HTTP status code is not 200-399.'
-          summary: HTTP Status Code (instance {{ $labels.instance }})
-        expr: probe_http_status_code <= 199 OR probe_http_status_code >= 400
-        for: 5m
-        labels:
-          severity: error
-          job: blackbox-exporter
-      - alert: SslCertExpiresIn15to10Days
-        annotations:
-          description: |-
-            SSL certificate expires in 15 days
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} ssl cert expires in 15 to 10 days.'
-          summary: SSL certificate will expire soon (instance {{ $labels.instance }})
-        expr: 86400 * 10 < probe_ssl_earliest_cert_expiry - time() < 86400 * 15
-        for: 5m
-        labels:
-          severity: warning
-          job: blackbox-exporter
-      - alert: SslCertExpiresIn10to5Days
-        annotations:
-          description: |-
-            SSL certificate expires in 10 days
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} ssl cert expires in 10 to 6 days.'
-          summary: SSL certificate will expire soon (instance {{ $labels.instance }})
-        expr: 86400 * 5 < probe_ssl_earliest_cert_expiry - time() < 86400 * 10
-        for: 5m
-        labels:
-          severity: warning
-          job: blackbox-exporter
-      - alert: SslCertExpiresIn5Days
-        annotations:
-          description: |-
-            SSL certificate expires in 5 days
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} ssl cert expires in 5 days.'
-          summary: SSL certificate will expire soon (instance {{ $labels.instance }})
-        expr: 86400 * 5 < probe_ssl_earliest_cert_expiry - time() < 86400 * 6
-        for: 5m
-        labels:
-          severity: warning
-          job: blackbox-exporter
-      - alert: SslCertExpiresIn4Days
-        annotations:
-          description: |-
-            SSL certificate expires in 4 days
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} ssl cert expires in 4 days.'
-          summary: SSL certificate will expire soon (instance {{ $labels.instance }})
-        expr: 86400 * 4 < probe_ssl_earliest_cert_expiry - time() < 86400 * 5
-        for: 5m
-        labels:
-          severity: warning
-      - alert: SslCertExpiresIn3Days
-        annotations:
-          description: |-
-            SSL certificate expires in 3 days
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} ssl cert expires in 3 days.'
-          summary: SSL certificate will expire soon (instance {{ $labels.instance }})
-        expr: 86400 * 3 < probe_ssl_earliest_cert_expiry - time() < 86400 * 4
-        for: 5m
-        labels:
-          job: blackbox-exporter
-          severity: warning
-      - alert: SslCertExpiresIn1Days
-        annotations:
-          description: |-
-            SSL certificate expires in 2 days
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} ssl cert expires in 2 days.'
-          summary: SSL certificate will expire soon (instance {{ $labels.instance }})
-        expr: 86400 * 2 < probe_ssl_earliest_cert_expiry - time() < 86400 * 3
-        for: 5m
-        labels:
-          severity: warning
-          job: blackbox-exporter
-      - alert: SslCertExpiresIn1Days
-        annotations:
-          description: |-
-            SSL certificate expires in 1 day
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} ssl cert expires in 2 days.'
-          summary: SSL certificate will expire soon (instance {{ $labels.instance }})
-        expr: 86400 * 1 < probe_ssl_earliest_cert_expiry - time() < 86400 * 2
-        for: 5m
-        labels:
-          severity: warning
-          job: blackbox-exporter
-      - alert: SslCertificateHasExpired
-        annotations:
-          description: |-
-            SSL certificate has expired already
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          summary: SSL certificate has expired (instance {{ $labels.instance }})
-        expr: probe_ssl_earliest_cert_expiry - time()  <= 0
-        for: 5m
-        labels:
-          severity: error
-          job: blackbox-exporter
-      - alert: SslCertExpiresIn15Days
-        annotations:
-          description: |-
-            SSL certificate expires in 15 days
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          summary: SSL certificate will expire soon (instance {{ $labels.instance }})
-          message: '{{ $labels.target }} ssl cert expires in 15 days.'
-        expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 15
-        for: 5m
-        labels:
-          severity: critical
-          job: blackbox-exporter
-      - alert: SslCertificateHasExpired
-        annotations:
-          description: |-
-            SSL certificate has expired already
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} SSL certificate expired.'
-          summary: SSL certificate has expired (instance {{ $labels.instance }})
-        expr: probe_ssl_earliest_cert_expiry - time()  <= 0
-        for: 5m
-        labels:
-          severity: error
-          job: blackbox-exporter
-      - alert: HttpSlowRequests
-        annotations:
-          description: |-
-            HTTP request took more than 2s
-              VALUE = {{ $value }}
-              LABELS: {{ $labels }}
-          message: '{{ $labels.target }} HTTP request took more than 2s.'
-          summary: HTTP slow requests (instance {{ $labels.instance }})
-        expr: avg_over_time(probe_http_duration_seconds[1m]) > 2
-        for: 5m
-        labels:
-          severity: warning
-          job: blackbox-exporter
-    - name: contiamo-rules
-      rules:
-      - alert: HeartBeat
-        annotations:
-          message: "Heartbeat alert from Prometheus. *Runbook Link*: <https://github.com/contiamo/cole#how-does-it-work|:notebook_with_decorative_cover:>"
-          environment: "ENV_SLUG_PLACEHOLDER"
-        expr: vector(1)
-        labels:
-          severity: none
-      - alert: KubePodCrashLooping
-        annotations:
-          grafana_log_path: explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bpod%3D%5C"{{
-            $labels.pod }}%5C",namespace%3D%5C"{{ $labels.namespace }}%5C"%7D"%7D,%7B"mode":"Logs"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D
-          #grafana_url: https://grafana.dev.contiamo.io/
-          grafana_url: https://${GRAFANA_HOST}
-          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
-            }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashloopingA
-        expr: increase(kube_pod_container_status_restarts_total{job="kube-state-metrics",namespace=~".*"}[5m]) > 0
-        for: 5m
-        labels:
-          severity: critical
-      - alert: KubePodNotReady
-        annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
-            state for longer than 15 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-        expr: sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job="kube-state-metrics",
-          namespace=~".*", phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind)
-          max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) >
-          0
-        for: 15m
-        labels:
-          severity: critical
-      - alert: KubeDeploymentGenerationMismatch
-        annotations:
-          message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
-            }} does not match, this indicates that the Deployment has failed but has
-            not been rolled back.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
-        expr: |-
-          kube_deployment_status_observed_generation{job="kube-state-metrics", namespace=~".*"}
-            !=
-          kube_deployment_metadata_generation{job="kube-state-metrics", namespace=~".*"}
-        for: 15m
-        labels:
-          severity: critical
-      - alert: KubeDeploymentReplicasMismatch
-        annotations:
-          message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
-            matched the expected number of replicas for longer than 15 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
-        expr: |-
-          (
-            kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~".*"}
-              !=
-            kube_deployment_status_replicas_available{job="kube-state-metrics", namespace=~".*"}
-          ) and (
-            changes(kube_deployment_status_replicas_updated{job="kube-state-metrics", namespace=~".*"}[5m])
-              ==
+  blackbox-exporter:
+    groups:
+      - name: blackbox-exporter
+        rules:
+        - alert: HttpProbeFailed
+          annotations:
+            description: |-
+              Probe failed
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} probe failed.'
+            summary: Probe failed (instance {{ $labels.instance }})
+          expr: probe_success == 0
+          for: 5m
+          labels:
+            severity: error
+            job: blackbox-exporter
+        - alert: SlowPing
+          annotations:
+            description: |-
+              Blackbox ping took more than 2s
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} Ping took more than 2s.'
+            summary: Slow ping (instance {{ $labels.instance }})
+          expr: avg_over_time(probe_icmp_duration_seconds[1m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+            job: blackbox-exporter
+        - alert: SlowProbe
+          annotations:
+            description: |-
+              Blackbox probe took more than 2s to complete
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} probe took more than 2s.'
+            summary: Slow probe (instance {{ $labels.instance }})
+          expr: avg_over_time(probe_duration_seconds[1m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+            job: blackbox-exporter
+        - alert: HttpStatusCode
+          annotations:
+            description: |-
+              HTTP status code is not 200-399
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} HTTP status code is not 200-399.'
+            summary: HTTP Status Code (instance {{ $labels.instance }})
+          expr: probe_http_status_code <= 199 OR probe_http_status_code >= 400
+          for: 5m
+          labels:
+            severity: error
+            job: blackbox-exporter
+        - alert: SslCertExpiresIn15to10Days
+          annotations:
+            description: |-
+              SSL certificate expires in 15 days
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} ssl cert expires in 15 to 10 days.'
+            summary: SSL certificate will expire soon (instance {{ $labels.instance }})
+          expr: 86400 * 10 < probe_ssl_earliest_cert_expiry - time() < 86400 * 15
+          for: 5m
+          labels:
+            severity: warning
+            job: blackbox-exporter
+        - alert: SslCertExpiresIn10to5Days
+          annotations:
+            description: |-
+              SSL certificate expires in 10 days
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} ssl cert expires in 10 to 6 days.'
+            summary: SSL certificate will expire soon (instance {{ $labels.instance }})
+          expr: 86400 * 5 < probe_ssl_earliest_cert_expiry - time() < 86400 * 10
+          for: 5m
+          labels:
+            severity: warning
+            job: blackbox-exporter
+        - alert: SslCertExpiresIn5Days
+          annotations:
+            description: |-
+              SSL certificate expires in 5 days
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} ssl cert expires in 5 days.'
+            summary: SSL certificate will expire soon (instance {{ $labels.instance }})
+          expr: 86400 * 5 < probe_ssl_earliest_cert_expiry - time() < 86400 * 6
+          for: 5m
+          labels:
+            severity: warning
+            job: blackbox-exporter
+        - alert: SslCertExpiresIn4Days
+          annotations:
+            description: |-
+              SSL certificate expires in 4 days
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} ssl cert expires in 4 days.'
+            summary: SSL certificate will expire soon (instance {{ $labels.instance }})
+          expr: 86400 * 4 < probe_ssl_earliest_cert_expiry - time() < 86400 * 5
+          for: 5m
+          labels:
+            severity: warning
+        - alert: SslCertExpiresIn3Days
+          annotations:
+            description: |-
+              SSL certificate expires in 3 days
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} ssl cert expires in 3 days.'
+            summary: SSL certificate will expire soon (instance {{ $labels.instance }})
+          expr: 86400 * 3 < probe_ssl_earliest_cert_expiry - time() < 86400 * 4
+          for: 5m
+          labels:
+            job: blackbox-exporter
+            severity: warning
+        - alert: SslCertExpiresIn1Days
+          annotations:
+            description: |-
+              SSL certificate expires in 2 days
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} ssl cert expires in 2 days.'
+            summary: SSL certificate will expire soon (instance {{ $labels.instance }})
+          expr: 86400 * 2 < probe_ssl_earliest_cert_expiry - time() < 86400 * 3
+          for: 5m
+          labels:
+            severity: warning
+            job: blackbox-exporter
+        - alert: SslCertExpiresIn1Days
+          annotations:
+            description: |-
+              SSL certificate expires in 1 day
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} ssl cert expires in 2 days.'
+            summary: SSL certificate will expire soon (instance {{ $labels.instance }})
+          expr: 86400 * 1 < probe_ssl_earliest_cert_expiry - time() < 86400 * 2
+          for: 5m
+          labels:
+            severity: warning
+            job: blackbox-exporter
+        - alert: SslCertificateHasExpired
+          annotations:
+            description: |-
+              SSL certificate has expired already
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            summary: SSL certificate has expired (instance {{ $labels.instance }})
+          expr: probe_ssl_earliest_cert_expiry - time()  <= 0
+          for: 5m
+          labels:
+            severity: error
+            job: blackbox-exporter
+        - alert: SslCertExpiresIn15Days
+          annotations:
+            description: |-
+              SSL certificate expires in 15 days
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            summary: SSL certificate will expire soon (instance {{ $labels.instance }})
+            message: '{{ $labels.target }} ssl cert expires in 15 days.'
+          expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 15
+          for: 5m
+          labels:
+            severity: critical
+            job: blackbox-exporter
+        - alert: SslCertificateHasExpired
+          annotations:
+            description: |-
+              SSL certificate has expired already
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} SSL certificate expired.'
+            summary: SSL certificate has expired (instance {{ $labels.instance }})
+          expr: probe_ssl_earliest_cert_expiry - time()  <= 0
+          for: 5m
+          labels:
+            severity: error
+            job: blackbox-exporter
+        - alert: HttpSlowRequests
+          annotations:
+            description: |-
+              HTTP request took more than 2s
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            message: '{{ $labels.target }} HTTP request took more than 2s.'
+            summary: HTTP slow requests (instance {{ $labels.instance }})
+          expr: avg_over_time(probe_http_duration_seconds[1m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+            job: blackbox-exporter
+  contiamo-rules:
+    groups:
+      - name: contiamo-rules
+        rules:
+        - alert: HeartBeat
+          annotations:
+            message: "Heartbeat alert from Prometheus. *Runbook Link*: <https://github.com/contiamo/cole#how-does-it-work|:notebook_with_decorative_cover:>"
+            environment: "ENV_SLUG_PLACEHOLDER"
+          expr: vector(1)
+          labels:
+            severity: none
+        - alert: KubePodCrashLooping
+          annotations:
+            grafana_log_path: explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bpod%3D%5C"{{
+              $labels.pod }}%5C",namespace%3D%5C"{{ $labels.namespace }}%5C"%7D"%7D,%7B"mode":"Logs"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D
+            #grafana_url: https://grafana.dev.contiamo.io/
+            grafana_url: https://${GRAFANA_HOST}
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+              }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashloopingA
+          expr: increase(kube_pod_container_status_restarts_total{job="kube-state-metrics",namespace=~".*"}[5m]) > 0
+          for: 5m
+          labels:
+            severity: critical
+        - alert: KubePodNotReady
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+              state for longer than 15 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+          expr: sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job="kube-state-metrics",
+            namespace=~".*", phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind)
+            max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) >
             0
-          )
-        for: 15m
-        labels:
-          severity: critical
-      - alert: KubeStatefulSetReplicasMismatch
-        annotations:
-          message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
-            not matched the expected number of replicas for longer than 15 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
-        expr: |-
-          (
-            kube_statefulset_status_replicas_ready{job="kube-state-metrics", namespace=~".*"}
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeDeploymentGenerationMismatch
+          annotations:
+            message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+              }} does not match, this indicates that the Deployment has failed but has
+              not been rolled back.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
+          expr: |-
+            kube_deployment_status_observed_generation{job="kube-state-metrics", namespace=~".*"}
               !=
-            kube_statefulset_status_replicas{job="kube-state-metrics", namespace=~".*"}
-          ) and (
-            changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~".*"}[5m])
+            kube_deployment_metadata_generation{job="kube-state-metrics", namespace=~".*"}
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeDeploymentReplicasMismatch
+          annotations:
+            message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+              matched the expected number of replicas for longer than 15 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
+          expr: |-
+            (
+              kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~".*"}
+                !=
+              kube_deployment_status_replicas_available{job="kube-state-metrics", namespace=~".*"}
+            ) and (
+              changes(kube_deployment_status_replicas_updated{job="kube-state-metrics", namespace=~".*"}[5m])
+                ==
+              0
+            )
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStatefulSetReplicasMismatch
+          annotations:
+            message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
+              not matched the expected number of replicas for longer than 15 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
+          expr: |-
+            (
+              kube_statefulset_status_replicas_ready{job="kube-state-metrics", namespace=~".*"}
+                !=
+              kube_statefulset_status_replicas{job="kube-state-metrics", namespace=~".*"}
+            ) and (
+              changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~".*"}[5m])
+                ==
+              0
+            )
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStatefulSetGenerationMismatch
+          annotations:
+            message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
+              }} does not match, this indicates that the StatefulSet has failed but has
+              not been rolled back.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
+          expr: |-
+            kube_statefulset_status_observed_generation{job="kube-state-metrics", namespace=~".*"}
+              !=
+            kube_statefulset_metadata_generation{job="kube-state-metrics", namespace=~".*"}
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStatefulSetUpdateNotRolledOut
+          annotations:
+            message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
+              has not been rolled out.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
+          expr: |-
+            max without (revision) (
+              kube_statefulset_status_current_revision{job="kube-state-metrics", namespace=~".*"}
+                unless
+              kube_statefulset_status_update_revision{job="kube-state-metrics", namespace=~".*"}
+            )
+              *
+            (
+              kube_statefulset_replicas{job="kube-state-metrics", namespace=~".*"}
+                !=
+              kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~".*"}
+            )
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeDaemonSetRolloutStuck
+          annotations:
+            message: Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet
+              {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
+          expr: |-
+            kube_daemonset_status_number_ready{job="kube-state-metrics", namespace=~".*"}
+              /
+            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~".*"} < 1.00
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeContainerWaiting
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}}
+              has been in waiting state for longer than 1 hour.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting
+          expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics",
+            namespace=~".*"}) > 0
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetNotScheduled
+          annotations:
+            message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+              }} are not scheduled.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled
+          expr: |-
+            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~".*"}
+              -
+            kube_daemonset_status_current_number_scheduled{job="kube-state-metrics", namespace=~".*"} > 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetMisScheduled
+          annotations:
+            message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+              }} are running where they are not supposed to run.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
+          expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics", namespace=~".*"}
+            > 0
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeCronJobRunning
+          annotations:
+            message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+              than 1h to complete.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
+          expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace=~".*"}
+            > 3600
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubeJobCompletion
+          annotations:
+            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+              than one hour to complete.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+          expr: kube_job_spec_completions{job="kube-state-metrics", namespace=~".*"} -
+            kube_job_status_succeeded{job="kube-state-metrics", namespace=~".*"}  > 0
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubeJobFailed
+          annotations:
+            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
+          expr: kube_job_failed{job="kube-state-metrics", namespace=~".*"}  > 0
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeHpaReplicasMismatch
+          annotations:
+            message: HPA {{ $labels.namespace }}/{{ $labels.hpa }} has not matched the
+              desired number of replicas for longer than 15 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch
+          expr: |-
+            (kube_hpa_status_desired_replicas{job="kube-state-metrics", namespace=~".*"}
+              !=
+            kube_hpa_status_current_replicas{job="kube-state-metrics", namespace=~".*"})
+              and
+            changes(kube_hpa_status_current_replicas[15m]) == 0
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeHpaMaxedOut
+          annotations:
+            message: HPA {{ $labels.namespace }}/{{ $labels.hpa }} has been running at
+              max replicas for longer than 15 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout
+          expr: |-
+            kube_hpa_status_current_replicas{job="kube-state-metrics", namespace=~".*"}
               ==
-            0
-          )
-        for: 15m
-        labels:
-          severity: critical
-      - alert: KubeStatefulSetGenerationMismatch
-        annotations:
-          message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
-            }} does not match, this indicates that the StatefulSet has failed but has
-            not been rolled back.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
-        expr: |-
-          kube_statefulset_status_observed_generation{job="kube-state-metrics", namespace=~".*"}
-            !=
-          kube_statefulset_metadata_generation{job="kube-state-metrics", namespace=~".*"}
-        for: 15m
-        labels:
-          severity: critical
-      - alert: KubeStatefulSetUpdateNotRolledOut
-        annotations:
-          message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
-            has not been rolled out.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
-        expr: |-
-          max without (revision) (
-            kube_statefulset_status_current_revision{job="kube-state-metrics", namespace=~".*"}
-              unless
-            kube_statefulset_status_update_revision{job="kube-state-metrics", namespace=~".*"}
-          )
-            *
-          (
-            kube_statefulset_replicas{job="kube-state-metrics", namespace=~".*"}
-              !=
-            kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~".*"}
-          )
-        for: 15m
-        labels:
-          severity: critical
-      - alert: KubeDaemonSetRolloutStuck
-        annotations:
-          message: Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet
-            {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
-        expr: |-
-          kube_daemonset_status_number_ready{job="kube-state-metrics", namespace=~".*"}
-            /
-          kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~".*"} < 1.00
-        for: 15m
-        labels:
-          severity: critical
-      - alert: KubeContainerWaiting
-        annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}}
-            has been in waiting state for longer than 1 hour.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting
-        expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics",
-          namespace=~".*"}) > 0
-        for: 1h
-        labels:
-          severity: warning
-      - alert: KubeDaemonSetNotScheduled
-        annotations:
-          message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
-            }} are not scheduled.'
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled
-        expr: |-
-          kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~".*"}
-            -
-          kube_daemonset_status_current_number_scheduled{job="kube-state-metrics", namespace=~".*"} > 0
-        for: 10m
-        labels:
-          severity: warning
-      - alert: KubeDaemonSetMisScheduled
-        annotations:
-          message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
-            }} are running where they are not supposed to run.'
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
-        expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics", namespace=~".*"}
-          > 0
-        for: 15m
-        labels:
-          severity: warning
-      - alert: KubeCronJobRunning
-        annotations:
-          message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
-            than 1h to complete.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
-        expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace=~".*"}
-          > 3600
-        for: 1h
-        labels:
-          severity: warning
-      - alert: KubeJobCompletion
-        annotations:
-          message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
-            than one hour to complete.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
-        expr: kube_job_spec_completions{job="kube-state-metrics", namespace=~".*"} -
-          kube_job_status_succeeded{job="kube-state-metrics", namespace=~".*"}  > 0
-        for: 1h
-        labels:
-          severity: warning
-      - alert: KubeJobFailed
-        annotations:
-          message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
-        expr: kube_job_failed{job="kube-state-metrics", namespace=~".*"}  > 0
-        for: 15m
-        labels:
-          severity: warning
-      - alert: KubeHpaReplicasMismatch
-        annotations:
-          message: HPA {{ $labels.namespace }}/{{ $labels.hpa }} has not matched the
-            desired number of replicas for longer than 15 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch
-        expr: |-
-          (kube_hpa_status_desired_replicas{job="kube-state-metrics", namespace=~".*"}
-            !=
-          kube_hpa_status_current_replicas{job="kube-state-metrics", namespace=~".*"})
-            and
-          changes(kube_hpa_status_current_replicas[15m]) == 0
-        for: 15m
-        labels:
-          severity: warning
-      - alert: KubeHpaMaxedOut
-        annotations:
-          message: HPA {{ $labels.namespace }}/{{ $labels.hpa }} has been running at
-            max replicas for longer than 15 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout
-        expr: |-
-          kube_hpa_status_current_replicas{job="kube-state-metrics", namespace=~".*"}
-            ==
-          kube_hpa_spec_max_replicas{job="kube-state-metrics", namespace=~".*"}
-        for: 15m
-        labels:
-          severity: warning
-      - alert: KubeCPUQuotaOvercommit
-        annotations:
-          message: Cluster has overcommitted CPU resource requests for Namespaces.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit
-        expr: |-
-          sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="cpu"})
-            /
-          sum(kube_node_status_allocatable_cpu_cores)
-            > 1.5
-        for: 5m
-        labels:
-          severity: warning
-      - alert: KubeMemoryQuotaOvercommit
-        annotations:
-          message: Cluster has overcommitted memory resource requests for Namespaces.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit
-        expr: |-
-          sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="memory"})
-            /
-          sum(kube_node_status_allocatable_memory_bytes{job="node-exporter"})
-            > 1.5
-        for: 5m
-        labels:
-          severity: warning
-      - alert: KubeQuotaExceeded
-        annotations:
-          message: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
-            }} of its {{ $labels.resource }} quota.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
-        expr: |-
-          kube_resourcequota{job="kube-state-metrics", type="used"}
-            / ignoring(instance, job, type)
-          (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
-            > 0.90
-        for: 15m
-        labels:
-          severity: warning
-      - alert: NginxError
-        annotations:
-          message: Ingress {{ $labels.ingress }} non 4**/5** response rate is {{ $value }} over last 1m.
-          runbook_url: https://github.com/contiamo/ops-docs/tree/master/runbook
-        expr: |-
-            sum(rate(nginx_ingress_controller_request_duration_seconds_count{status =~"[4-5].*",}[1m])) > 10.00
-        for: 5m
-        labels:
-          severity: warning
-      - alert: NginxErrors
-        annotations:
-          message: 'Ingress 4-- or 5-- responses over last minute: {{ $value }}.'
-          runbook_url: https://github.com/contiamo/ops-docs/tree/master/runbook/NginxIngressMetrics.md#nginxlatency
-        expr: sum(rate(nginx_ingress_controller_request_duration_seconds_count{status=~"[4-5].*",}[1m])) by(path, status, ingress, namespace) > 10.00
-        for: 1m
-        labels:
-          severity: warning
-      - alert: NginxLatency
-        annotations:
-          message: Ingress {{ $labels.host }} 99th req. latency percentile {{ $value }}.
-          runbook_url: https://github.com/contiamo/ops-docs/tree/master/runbook/NginxIngressMetrics.md#nginxerrors
-        expr: histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=""}[5m])) by (le, ingress, host, exported_namespace)) > 10
-        for: 10m
-        labels:
-          severity: warning
+            kube_hpa_spec_max_replicas{job="kube-state-metrics", namespace=~".*"}
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeCPUQuotaOvercommit
+          annotations:
+            message: Cluster has overcommitted CPU resource requests for Namespaces.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit
+          expr: |-
+            sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="cpu"})
+              /
+            sum(kube_node_status_allocatable_cpu_cores)
+              > 1.5
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeMemoryQuotaOvercommit
+          annotations:
+            message: Cluster has overcommitted memory resource requests for Namespaces.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit
+          expr: |-
+            sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="memory"})
+              /
+            sum(kube_node_status_allocatable_memory_bytes{job="node-exporter"})
+              > 1.5
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeQuotaExceeded
+          annotations:
+            message: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+          expr: |-
+            kube_resourcequota{job="kube-state-metrics", type="used"}
+              / ignoring(instance, job, type)
+            (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+              > 0.90
+          for: 15m
+          labels:
+            severity: warning
+        - alert: NginxError
+          annotations:
+            message: Ingress {{ $labels.ingress }} non 4**/5** response rate is {{ $value }} over last 1m.
+            runbook_url: https://github.com/contiamo/ops-docs/tree/master/runbook
+          expr: |-
+              sum(rate(nginx_ingress_controller_request_duration_seconds_count{status =~"[4-5].*",}[1m])) > 10.00
+          for: 5m
+          labels:
+            severity: warning
+        - alert: NginxErrors
+          annotations:
+            message: 'Ingress 4-- or 5-- responses over last minute: {{ $value }}.'
+            runbook_url: https://github.com/contiamo/ops-docs/tree/master/runbook/NginxIngressMetrics.md#nginxlatency
+          expr: sum(rate(nginx_ingress_controller_request_duration_seconds_count{status=~"[4-5].*",}[1m])) by(path, status, ingress, namespace) > 10.00
+          for: 1m
+          labels:
+            severity: warning
+        - alert: NginxLatency
+          annotations:
+            message: Ingress {{ $labels.host }} 99th req. latency percentile {{ $value }}.
+            runbook_url: https://github.com/contiamo/ops-docs/tree/master/runbook/NginxIngressMetrics.md#nginxerrors
+          expr: histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=""}[5m])) by (le, ingress, host, exported_namespace)) > 10
+          for: 10m
+          labels:
+            severity: warning

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -111,15 +111,18 @@ resource "helm_release" "monitoring" {
   values = [
     templatefile("${path.module}/assets/helm-values-monitoring.tpl",
       {
-        GRAFANA_PVC_SIZE                 = var.grafana_pvc_size,
-        GRAFANA_INGRESS_CLASS_NAME       = var.grafana_ingress_class_name,
-        CERT_MANAGER_CLUSTER_ISSUER_NAME = var.cert_manager_cluster_issuer_name,
-        GRAFANA_HOST                     = var.grafana_host,
-        GRAFANA_ADMIN_USER               = var.grafana_admin_user,
-        GRAFANA_ADMIN_PASSWORD           = var.grafana_admin_password,
-        ALERT_MANAGER_INGRESS_CLASS_NAME = var.alert_manager_ingress_class_name,
-        ALERT_MANAGER_HOST               = var.alert_manager_host,
-        ALERT_MANAGER_SLACK_WEBHOOK_URL  = var.alert_manager_slack_webhook_url,
+        GRAFANA_PVC_SIZE                        = var.grafana_pvc_size,
+        GRAFANA_GATEWAY_NAME                    = var.grafana_gateway_parent_ref.name,
+        GRAFANA_GATEWAY_NAMESPACE               = var.grafana_gateway_parent_ref.namespace,
+        GRAFANA_GATEWAY_SECTION                 = var.grafana_gateway_parent_ref.section_name,
+        GRAFANA_HOST                            = var.grafana_host,
+        GRAFANA_ADMIN_USER                      = var.grafana_admin_user,
+        GRAFANA_ADMIN_PASSWORD                  = var.grafana_admin_password,
+        ALERT_MANAGER_GATEWAY_NAME              = var.alert_manager_gateway_parent_ref.name,
+        ALERT_MANAGER_GATEWAY_NAMESPACE         = var.alert_manager_gateway_parent_ref.namespace,
+        ALERT_MANAGER_GATEWAY_SECTION           = var.alert_manager_gateway_parent_ref.section_name,
+        ALERT_MANAGER_HOST                      = var.alert_manager_host,
+        ALERT_MANAGER_SLACK_WEBHOOK_URL         = var.alert_manager_slack_webhook_url,
         ALERT_MANAGER_SLACK_WEBHOOK_URL_WEB_ENDPOINT_MONITORING = var.alert_manager_slack_webhook_url_web_endpoint_monitoring,
       }
     )

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -6,7 +6,7 @@ variable "target_namespace" {
 
 variable "kube_prometheus_version" {
   type        = string
-  description = "ube-prometheus-stack Helm chart version."
+  description = "kube-prometheus-stack Helm chart version."
 }
 
 variable "loki_version" {
@@ -21,14 +21,14 @@ variable "loki_storage_bucket_name" {
 
 variable "aws_tags" {
   type        = map(string)
-  description = "Tags to apply to AWS resources. S3 bucket  for Loki stprage and IAM rile for Loki service account."
+  description = "Tags to apply to AWS resources. S3 bucket for Loki storage and IAM role for Loki service account."
   default = {
     "ManagedBy" = "Terraform"
   }
 }
 variable "oidc_provider_arn" {
   type        = string
-  description = "The ARN of the OIDC provider for the EKS cluster. Will be used to define Loki service-account access to the stoarge S3 bucket."
+  description = "The ARN of the OIDC provider for the EKS cluster. Will be used to define Loki service-account access to the storage S3 bucket."
 }
 
 variable "grafana_admin_user" {
@@ -45,13 +45,22 @@ variable "grafana_pvc_size" {
   type        = string
 }
 
-variable "grafana_ingress_class_name" {
-  description = "The class name for the Grafana Ingress"
-  type        = string
+variable "grafana_gateway_parent_ref" {
+  description = "Gateway parentRef for the Grafana HTTPRoute (name/namespace/sectionName)."
+  type = object({
+    name         = string
+    namespace    = string
+    section_name = string
+  })
 }
-variable "alert_manager_ingress_class_name" {
-  description = "The class name for the Alert Manager Ingress"
-  type        = string
+
+variable "alert_manager_gateway_parent_ref" {
+  description = "Gateway parentRef for the Alertmanager HTTPRoute (name/namespace/sectionName)."
+  type = object({
+    name         = string
+    namespace    = string
+    section_name = string
+  })
 }
 variable "alert_manager_host" {
   description = "The host for Alert Manager"
@@ -67,11 +76,6 @@ variable "alert_manager_slack_webhook_url_web_endpoint_monitoring" {
   type        = string
   sensitive   = true
 }
-variable "cert_manager_cluster_issuer_name" {
-  description = "The name of the Cert Manager Cluster Issuer"
-  type        = string
-}
-
 variable "grafana_host" {
   description = "The host for Grafana"
   type        = string


### PR DESCRIPTION
## Summary

- Bump `kube-prometheus-stack` Helm chart from 72.6.2 → **83.4.3**
- Migrate Grafana and Alertmanager exposure from nginx Ingress to Gateway API HTTPRoute (native `route.main.enabled: true` in the chart's values schema)
- Convert `additionalPrometheusRulesMap` from list form (silently tolerated by 72.x) to proper map form required by 83.x
- Fix a handful of typos in variable descriptions

## Breaking changes

- **Removed variables**:
  - `grafana_ingress_class_name`
  - `alert_manager_ingress_class_name`
  - `cert_manager_cluster_issuer_name` (no longer used — Gateway certs are handled by cert-manager watching the Gateway annotation, not per-Ingress)
- **New variables** (both required):
  - `grafana_gateway_parent_ref` — object with `name`, `namespace`, `section_name` fields, identifying the Gateway listener the Grafana HTTPRoute attaches to
  - `alert_manager_gateway_parent_ref` — same shape for Alertmanager

Callers must pass the parent ref matching their cluster's shared Envoy Gateway (e.g. `envoy-tailscale` / `envoy-gateway-system` / `https-ctmo` for Contiamo EKS).

## Verified on Contiamo EKS

Applied via Scalr run \`run-v0p7o7eb6ovret179\` using the commit-pinned module ref (`?ref=082744c`). Post-apply checks:

- Grafana HTTPRoute \`monitoring-stack-grafana\` Accepted, serving at https://grafana.ctmo.io (HTTP 200 on /api/health)
- Alertmanager HTTPRoute \`monitoring-stack-kube-prom-alertmanager\` Accepted, serving at https://alertmanager.ctmo.io (HTTP 200)
- `additionalPrometheusRulesMap` now renders as \`monitoring-stack-kube-prom-blackbox-exporter\` and \`monitoring-stack-kube-prom-contiamo-rules\` — the previously orphaned \`kube-prometheus-stack-0\` rule (from the list-form render under 72.x) was replaced cleanly by Helm's 3-way merge
- No Ingress resources remain in the monitoring namespace

## Rollout story

The first two apply attempts errored with `PrometheusRule monitoring-stack-kube-prom-%!s(int=0)` — Go's fmt badverb output when the 83.x template ran `printf "%s" $name` with `$name` being an integer index. Root cause: 72.x accepted `additionalPrometheusRulesMap` as a list, 83.x expects a map. Commit 082744c fixes this.

A secondary issue: Scalr's module cache kept reusing the stale 9c35f38 render across fresh runs even after the fix landed on the branch. Workaround was to pin the caller's ref to the commit SHA, which changed the go-getter source string and forced a fresh cache entry. Project-ops will be un-pinned back to a proper version tag (e.g. v0.15.0) once this PR merges and release-please tags a release.

## Follow-up

- After merge, let release-please tag a new monitoring module release
- Update `Contiamo/eks-cluster/monitoring.tf` in project-ops to reference the new tag instead of `ref=082744c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)