### PR TITLE
feat(envoy-gateway): add per-gateway annotations field

### DIFF
--- a/envoy-gateway/README.md
+++ b/envoy-gateway/README.md
@@ -148,6 +148,7 @@ module "envoy_gateway" {
 | envoyproxy_name | Custom EnvoyProxy resource name | `string` | `"{name}-proxy"` |
 | listeners | List of listener configs | `list(object)` | required |
 | lb_annotations | LoadBalancer annotations | `map(string)` | required |
+| gateway_annotations | Extra annotations on the Gateway resource (merged with the cert-manager annotation) | `map(string)` | `{}` |
 | tls_secret_suffix | TLS secret suffix pattern | `string` | `"-tls-{idx}"` |
 | cert_manager_issuer | Override default issuer | `string` | null |
 

--- a/envoy-gateway/main.tf
+++ b/envoy-gateway/main.tf
@@ -158,9 +158,12 @@ resource "kubectl_manifest" "gateway" {
     metadata = {
       name      = each.key
       namespace = var.namespace
-      annotations = {
-        "cert-manager.io/cluster-issuer" = coalesce(each.value.cert_manager_issuer, var.cert_manager_cluster_issuer)
-      }
+      annotations = merge(
+        {
+          "cert-manager.io/cluster-issuer" = coalesce(each.value.cert_manager_issuer, var.cert_manager_cluster_issuer)
+        },
+        each.value.gateway_annotations,
+      )
     }
     spec = {
       gatewayClassName = each.key

--- a/envoy-gateway/variables.tf
+++ b/envoy-gateway/variables.tf
@@ -44,9 +44,10 @@ variable "gateways" {
       domain = string # Domain pattern (e.g., "*.ctmo.io")
       name   = string # Listener name suffix (e.g., "ctmo" -> "http-ctmo", "https-ctmo")
     }))
-    lb_annotations      = map(string)      # LoadBalancer service annotations
-    tls_secret_suffix   = optional(string) # TLS secret suffix pattern (default: "-tls-{idx}")
-    cert_manager_issuer = optional(string) # Override default cert-manager issuer
+    lb_annotations      = map(string)               # LoadBalancer service annotations
+    gateway_annotations = optional(map(string), {}) # Extra annotations applied to the Gateway resource (merged with the cert-manager annotation)
+    tls_secret_suffix   = optional(string)          # TLS secret suffix pattern (default: "-tls-{idx}")
+    cert_manager_issuer = optional(string)          # Override default cert-manager issuer
   }))
 
   validation {


### PR DESCRIPTION
## Summary

Add an optional `gateway_annotations = map(string)` field to each entry in the `gateways` variable. The map is **merged** with the existing hardcoded `cert-manager.io/cluster-issuer` annotation on the Gateway resource.

## Why

On the OTC CCE cluster, the public ELB Service is dual-homed (a public EIP and a VPC-internal IP). external-dns publishes both targets to Route 53, so ~50% of public DNS lookups return an unroutable RFC1918 address. CON-2429.

Setting the gateway-level annotation \`external-dns.alpha.kubernetes.io/target=<public-eip>\` overrides the target for all child HTTPRoutes attached to that gateway. external-dns honors Gateway-level annotations per its Gateway API source. Verified working today via a manual \`kubectl annotate\` against the OTC envoy-public Gateway — the stale \`192.168.0.98\` target dropped from Route 53 within one reconcile cycle, and headlamp.otc.ctmo.io (attached to envoy-tailscale) was not affected.

EKS doesn't hit this case (its NLB exposes a DNS hostname, not raw IPs in the Service status), so the new field stays optional with default \`{}\`.

## Backward compatibility

The new field has \`optional(map(string), {})\` so existing callers (Contiamo EKS, OTC CCE) keep working unchanged. With an empty map, \`merge\` returns the same single-entry annotations map as before — no plan diff.

## Caller migration after release

\`Contiamo/otc-cce-cluster/envoy-gateway.tf\` will set:

\`\`\`hcl
gateway_annotations = {
  \"external-dns.alpha.kubernetes.io/target\" = \"164.30.7.132\"  # the public EIP
}
\`\`\`

on the \`envoy-public\` entry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)