### PR TITLE
feat(envoy-gateway): add per-listener tls_secret_name override

### DIFF
--- a/envoy-gateway/README.md
+++ b/envoy-gateway/README.md
@@ -154,10 +154,11 @@ module "envoy_gateway" {
 
 ### Listener Object
 
-| Field | Description |
-|-------|-------------|
-| domain | Domain pattern (e.g., `"*.example.com"`) |
-| name | Listener name suffix (creates `http-{name}` and `https-{name}`) |
+| Field | Description | Default |
+|-------|-------------|---------|
+| domain | Domain pattern (e.g., `"*.example.com"`) | required |
+| name | Listener name suffix (creates `http-{name}` and `https-{name}`) | required |
+| tls_secret_name | Override the auto-generated TLS Secret name. Use when reusing a Secret managed elsewhere (e.g. by an existing nginx Ingress's cert-manager Certificate) so cutover does not require a fresh ACME issuance. If unset, the Secret name is derived from `tls_secret_suffix` on the parent Gateway. | derived |
 
 ## Outputs
 

--- a/envoy-gateway/main.tf
+++ b/envoy-gateway/main.tf
@@ -17,12 +17,19 @@ locals {
     for gw in var.gateways : gw.name => gw if gw.enabled
   }
 
-  # Generate TLS secret names for each gateway's listeners
+  # Resolve TLS secret names for each gateway's listeners. A listener may
+  # override `tls_secret_name` to reference a Secret managed elsewhere
+  # (e.g. an existing nginx Ingress's cert-manager Certificate that we
+  # don't want to re-issue during a cutover); otherwise the name is
+  # derived from `tls_secret_suffix`.
   gateway_tls_secrets = {
     for gw_name, gw in local.enabled_gateways : gw_name => {
-      for listener in gw.listeners : listener.name => replace(
-        "${gw.name}${coalesce(gw.tls_secret_suffix, "-tls-{idx}")}",
-        "{idx}", listener.name
+      for listener in gw.listeners : listener.name => coalesce(
+        listener.tls_secret_name,
+        replace(
+          "${gw.name}${coalesce(gw.tls_secret_suffix, "-tls-{idx}")}",
+          "{idx}", listener.name,
+        ),
       )
     }
   }

--- a/envoy-gateway/variables.tf
+++ b/envoy-gateway/variables.tf
@@ -41,8 +41,9 @@ variable "gateways" {
     enabled         = optional(bool, true) # Whether to create this gateway
     envoyproxy_name = optional(string)     # Custom EnvoyProxy name (defaults to "{name}-proxy")
     listeners = list(object({
-      domain = string # Domain pattern (e.g., "*.ctmo.io")
-      name   = string # Listener name suffix (e.g., "ctmo" -> "http-ctmo", "https-ctmo")
+      domain          = string           # Domain pattern (e.g., "*.ctmo.io")
+      name            = string           # Listener name suffix (e.g., "ctmo" -> "http-ctmo", "https-ctmo")
+      tls_secret_name = optional(string) # Override the auto-generated TLS secret name. Use when reusing a Secret managed elsewhere (e.g. by an existing nginx Ingress) to avoid a fresh ACME issuance during cutover. If unset, the secret name is derived from `tls_secret_suffix`.
     }))
     lb_annotations      = map(string)               # LoadBalancer service annotations
     gateway_annotations = optional(map(string), {}) # Extra annotations applied to the Gateway resource (merged with the cert-manager annotation)


### PR DESCRIPTION
## Summary

Adds an optional `tls_secret_name` field on each Gateway listener so a listener can reference a TLS Secret by an explicit name instead of the auto-generated one derived from `tls_secret_suffix`. Backwards compatible: when unset, behaviour is unchanged.

## Why

When migrating an app from an existing nginx Ingress to a new Envoy Gateway listener, the existing Ingress's cert-manager-managed Secret already covers the relevant hostname(s) and is being kept current via the existing Certificate. Wiring the new listener to that same Secret sidesteps the chicken-and-egg of issuing a Let's Encrypt cert before DNS has been flipped to envoy.

## First consumer

The OTC `Contiamo/otc-cce-cluster/envoy-gateway.tf` will add a `chat.stadtwerke-bonn.de` listener to the existing `envoy-public` Gateway, pointing it at a copy of the existing nginx Ingress's `swb-chat-auto-generated` Secret. Part of [CON-2436](https://linear.app/contiamo/issue/CON-2436).

## Test plan

- [x] `tofu validate` passes on the module
- [x] `tofu plan` against `Contiamo/otc-cce-cluster` (with the module pinned to this branch) shows only two in-place updates: a new HTTPS listener with the explicit Secret reference, and the HTTP-redirect HTTPRoute gaining a corresponding `http-swb-chat` parentRef. No existing listeners touched.