### PR TITLE
feat(monitoring): OAuth, non-EKS Loki, plugins, multi-org dashboards

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,33 +1,118 @@
-# Monitoring Stack for EKS
+# Monitoring stack
 
-This module sets up Grafana, Prometheus, Loki and Promtail stack.
-This is all you need to monitor your EKS cluster.
+Sets up the standard Contiamo Grafana / Prometheus / Alertmanager / Loki stack on a Kubernetes cluster, fronted by Gateway API (Envoy Gateway). Log shipping is provided by Grafana Alloy (replaces promtail).
 
-## Usage:
+Two flavours are supported via `target_cluster`:
+
+- **`eks` (default)** — Loki uses IRSA to talk to its S3 bucket; PVCs use the cluster's default StorageClass.
+- **anything else (e.g. OTC CCE)** — Loki uses static AWS access keys (passed in via variables) and PVCs use the StorageClass given in `loki_storage_class_name` and `grafana_pvc_storage_class`.
+
+The stack assumes:
+
+- Gateway API + Envoy Gateway are already installed on the cluster (use the `envoy-gateway` and `gateway-api-crds` modules).
+- A Gateway resource exists with HTTPS listener sections that the caller can reference for Grafana and Alertmanager.
+
+## EKS usage
 
 ```hcl
 module "monitoring" {
   # contiamo-release-please-bump-start
-  source                            = "github.com/contiamo/terraform//monitoring?ref=v0.18.0"
+  source = "github.com/contiamo/terraform//monitoring?ref=v0.19.0"
   # contiamo-release-please-bump-end
-  target_namespace                  = "monitoring"
-  kube_prometheus_version           = "60.2.0"
-  promtail_version                  = "6.16.0"
-  loki_version                      = "6.6.3"
-  loki_storage_bucket_name          = "my-loki-storage" # this bucket will be created for you.
-  oidc_provider_arn                 = module.eks.oidc_provider_arn # If you used the EKS module to create your cluster simply use this value.
-  grafana_pvc_size                  = "50Gi"
-  grafana_ingress_class_name        = "nginx-internal" # the name of your NGINX ingress class
-  cert_manager_cluster_issuer_name  = local.cert_manager_cluster_issuer_name
-  grafana_host                      = # Grafana host
-  grafana_admin_user                = "contiamo"
-  grafana_admin_password            = random_password.grafana.result # Generate your password in TF or use your own value here.
-  alert_manager_ingress_class_name  = "nginx-internal" # the name of your NGINX ingress class
-  alert_manager_host                = # Alertmanager host
-  alert_manager_slack_webhook_url   = # Slack webhook for Alertmanager alerts
+
+  target_namespace        = "monitoring"
+  kube_prometheus_version = "83.4.3"
+  loki_version            = "6.23.0"
+  loki_storage_bucket_name = "my-loki-storage"
+  oidc_provider_arn       = module.eks.oidc_provider_arn
+
+  grafana_admin_user     = "contiamo"
+  grafana_admin_password = random_password.grafana.result
+  grafana_pvc_size       = "10Gi"
+
+  grafana_gateway_parent_ref = {
+    name         = "envoy-public"
+    namespace    = "envoy-gateway-system"
+    section_name = "https-example-com"
+  }
+  grafana_host = "grafana.example.com"
+
+  alert_manager_gateway_parent_ref = {
+    name         = "envoy-public"
+    namespace    = "envoy-gateway-system"
+    section_name = "https-example-com"
+  }
+  alert_manager_host              = "alertmanager.example.com"
+  alert_manager_slack_webhook_url = var.slack_webhook
 
   aws_tags = {
-    "ManagedBy"          = "Terraform",
+    "ManagedBy" = "Terraform"
   }
 }
+```
+
+## Non-EKS usage (e.g. OTC CCE)
+
+```hcl
+module "monitoring" {
+  # contiamo-release-please-bump-start
+  source = "github.com/contiamo/terraform//monitoring?ref=v0.19.0"
+  # contiamo-release-please-bump-end
+
+  target_cluster                        = "otc"
+  target_namespace                      = "monitoring"
+  kube_prometheus_version               = "83.4.3"
+  loki_version                          = "6.23.0"
+  loki_storage_bucket_name              = "my-loki-storage"
+  loki_storage_bucket_access_key_id     = aws_iam_access_key.loki.id
+  loki_storage_bucket_secret_access_key = aws_iam_access_key.loki.secret
+  loki_storage_class_name               = "csi-disk"
+
+  grafana_admin_user        = "contiamo"
+  grafana_admin_password    = random_password.grafana.result
+  grafana_pvc_size          = "10Gi"
+  grafana_pvc_storage_class = "csi-disk"
+
+  grafana_gateway_parent_ref = {
+    name         = "envoy-public"
+    namespace    = "envoy-gateway-system"
+    section_name = "https-example-com"
+  }
+  grafana_host = "grafana.example.com"
+
+  alert_manager_gateway_parent_ref = {
+    name         = "envoy-tailscale"
+    namespace    = "envoy-gateway-system"
+    section_name = "https-example-com"
+  }
+  alert_manager_host              = "alertmanager.example.com"
+  alert_manager_slack_webhook_url = var.slack_webhook
+}
+```
+
+## Optional features
+
+### Grafana plugins
+
+```hcl
+grafana_plugins = ["yesoreyeram-infinity-datasource"]
+```
+
+### OAuth / OIDC sign-in
+
+Set `grafana_oauth_enabled = true` and provide the standard generic-OAuth fields. The `grafana_oauth_role_attribute_path` JMESPath expression maps OAuth roles to Grafana roles, e.g.:
+
+```hcl
+grafana_oauth_role_attribute_path = "contains(roles[*], 'grafana-admin') && 'Admin' || contains(roles[*], 'grafana-viewer') && 'Viewer'"
+grafana_oauth_role_attribute_strict = true
+```
+
+### Multi-org dashboard provisioning
+
+`grafana_extra_dashboard_providers` mounts additional dashboard ConfigMaps into Grafana and provisions them into the specified org. Use this to ship dashboards into orgs other than the default Contiamo org.
+
+```hcl
+grafana_extra_dashboard_providers = [
+  { name = "ewr-genai", org_id = 2, configmap_name = "langfuse-ewr-dev-metrics-dashboard" }
+]
 ```

--- a/monitoring/assets/helm-values-loki-non-eks.tpl
+++ b/monitoring/assets/helm-values-loki-non-eks.tpl
@@ -1,0 +1,37 @@
+loki:
+  persistence:
+    enabled: true
+    storageClassName: ${LOKI_STORAGE_CLASS_NAME}
+  auth_enabled: false
+  storage:
+    type: "s3"
+    s3:
+      region: ${LOKI_BUCKET_AWS_REGION}
+      secretAccessKey: ${LOKI_STORAGE_BUCKET_SECRET_ACCESS_KEY}
+      accessKeyId: ${LOKI_STORAGE_BUCKET_ACCESS_KEY_ID}
+    bucketNames:
+      chunks: ${LOKI_STORAGE_BUCKET_NAME}
+      ruler: ${LOKI_STORAGE_BUCKET_NAME}
+      admin: ${LOKI_STORAGE_BUCKET_NAME}
+  schemaConfig:
+  # Taken from https://grafana.com/docs/loki/latest/operations/storage/schema/ This must be specified for new Loki installs.
+    configs:
+      - from: 2024-06-17 # for a new install, this must be a date in the past, use a recent date. Format is YYYY-MM-DD.
+        object_store: s3
+        store: tsdb # tsdb is the current and only recommended value for store.
+        schema: v13 # v13 is the most recent schema and recommended value.
+        index:
+          prefix: index_ # any value without spaces is acceptable.
+          period: 24h # must be 24h.
+read:
+  replicas: 2
+write:
+  replicas: 2
+  persistence:
+    storageClass: ${LOKI_STORAGE_CLASS_NAME}
+backend:
+  replicas: 2
+  persistence:
+    storageClass: ${LOKI_STORAGE_CLASS_NAME}
+global:
+  dnsService: coredns

--- a/monitoring/assets/helm-values-monitoring.tpl
+++ b/monitoring/assets/helm-values-monitoring.tpl
@@ -3,19 +3,84 @@ coreDns:
 kubeDns:
   enabled: false
 
-# Top-level upgradeJob for CRDs
-upgradeJob:
-  enabled: true
+# Required by kube-prometheus-stack 83.x to upgrade CRDs in place rather
+# than requiring out-of-band kubectl runs.
+crds:
+  upgradeJob:
+    enabled: true
 
 grafana:
+  assertNoLeakedSecrets: false
   adminUser: ${GRAFANA_ADMIN_USER}
   adminPassword: ${GRAFANA_ADMIN_PASSWORD}
+  grafana.ini:
+%{ if GRAFANA_AUTO_ASSIGN_ORG_ID > 0 ~}
+    users:
+      auto_assign_org_id: ${GRAFANA_AUTO_ASSIGN_ORG_ID}
+%{ endif ~}
+    server:
+      root_url: https://${GRAFANA_HOST}
+%{ if GRAFANA_OAUTH_ENABLED ~}
+    auth.generic_oauth:
+      enabled: true
+      name: ${GRAFANA_OAUTH_NAME}
+      client_id: ${GRAFANA_OAUTH_CLIENT_ID}
+      client_secret: ${GRAFANA_OAUTH_CLIENT_SECRET}
+      scopes: ${GRAFANA_OAUTH_SCOPES}
+      auth_url: ${GRAFANA_OAUTH_AUTH_URL}
+      token_url: ${GRAFANA_OAUTH_TOKEN_URL}
+      api_url: ${GRAFANA_OAUTH_API_URL}
+%{ if GRAFANA_OAUTH_ROLE_ATTRIBUTE_PATH != "" ~}
+      role_attribute_path: ${GRAFANA_OAUTH_ROLE_ATTRIBUTE_PATH}
+%{ endif ~}
+      role_attribute_strict: ${GRAFANA_OAUTH_ROLE_ATTRIBUTE_STRICT}
+      use_refresh_token: ${GRAFANA_OAUTH_USE_REFRESH_TOKEN}
+      auto_login: ${GRAFANA_OAUTH_AUTO_LOGIN}
+      skip_org_role_sync: ${GRAFANA_OAUTH_SKIP_ORG_ROLE_SYNC}
+%{ endif ~}
+%{ if length(GRAFANA_PLUGINS) > 0 ~}
+  plugins:
+%{ for plugin in GRAFANA_PLUGINS ~}
+    - ${plugin}
+%{ endfor ~}
+%{ endif ~}
+%{ if length(GRAFANA_EXTRA_DASHBOARD_PROVIDERS) > 0 ~}
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+%{ for provider in GRAFANA_EXTRA_DASHBOARD_PROVIDERS ~}
+        - name: '${provider.name}'
+          orgId: ${provider.org_id}
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/${provider.name}
+%{ endfor ~}
+  extraVolumeMounts:
+%{ for provider in GRAFANA_EXTRA_DASHBOARD_PROVIDERS ~}
+    - name: dashboards-${provider.name}
+      mountPath: /var/lib/grafana/dashboards/${provider.name}
+%{ endfor ~}
+  extraVolumes:
+%{ for provider in GRAFANA_EXTRA_DASHBOARD_PROVIDERS ~}
+    - name: dashboards-${provider.name}
+      configMap:
+        name: ${provider.configmap_name}
+%{ endfor ~}
+%{ endif ~}
   persistence:
     type: pvc
-    enabled: false
+    enabled: true
+    storageClassName: ${GRAFANA_PVC_STORAGE_CLASS}
     accessModes:
       - ReadWriteOnce
     size: ${GRAFANA_PVC_SIZE}
+  # RWO PVC + RollingUpdate causes Multi-Attach errors on upgrade. Force the
+  # old pod to terminate (releasing the volume) before the new one starts.
+  deploymentStrategy:
+    type: Recreate
   ingress:
     enabled: false
   route:

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -1,5 +1,9 @@
 locals {
-  loki_svc_account_name = "loki"
+  loki_svc_account_name           = "loki"
+  is_eks                          = var.target_cluster == "eks"
+  loki_values_template            = local.is_eks ? "${path.module}/assets/helm-values-loki.tpl" : "${path.module}/assets/helm-values-loki-non-eks.tpl"
+  loki_role_arn                   = local.is_eks ? module.loki_service_account_role[0].arn : ""
+  web_endpoint_monitoring_webhook = var.alert_manager_slack_webhook_url_web_endpoint_monitoring != "" ? var.alert_manager_slack_webhook_url_web_endpoint_monitoring : var.alert_manager_slack_webhook_url
 }
 
 # Prep. namespace:
@@ -14,8 +18,10 @@ resource "aws_s3_bucket" "loki_storage" {
   tags   = var.aws_tags
 }
 
-# Grant Loki access to the new bucket via a dedicated role:
+# Grant Loki access to the new bucket via a dedicated role (EKS only — non-EKS
+# clusters use static AWS credentials passed through the Helm values).
 resource "aws_iam_policy" "loki_storage_policy" {
+  count       = local.is_eks ? 1 : 0
   name        = "loki-svc-account-policy"
   description = "Policy for Loki storage bucket"
   policy = jsonencode({
@@ -36,15 +42,16 @@ resource "aws_iam_policy" "loki_storage_policy" {
 }
 
 module "loki_service_account_role" {
-  source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version   = "6.2.1"
-  name = "loki-svc-account-role"
+  count   = local.is_eks ? 1 : 0
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "6.2.1"
+  name    = "loki-svc-account-role"
   policies = {
-    bucket = aws_iam_policy.loki_storage_policy.arn,
+    bucket = aws_iam_policy.loki_storage_policy[0].arn,
   }
   oidc_providers = {
     one = {
-      provider_arn = "${var.oidc_provider_arn}"
+      provider_arn = var.oidc_provider_arn
       namespace_service_accounts = [
         "${kubernetes_namespace_v1.monitoring.metadata[0].name}:${local.loki_svc_account_name}"
       ]
@@ -66,12 +73,15 @@ resource "helm_release" "loki" {
   version    = var.loki_version
   namespace  = kubernetes_namespace_v1.monitoring.metadata[0].name
   values = [
-    templatefile("${path.module}/assets/helm-values-loki.tpl",
+    templatefile(local.loki_values_template,
       {
-        LOKI_BUCKET_AWS_REGION        = data.aws_region.current.id,
-        LOKI_STORAGE_BUCKET_NAME      = aws_s3_bucket.loki_storage.id,
-        LOKI_SVC_ACCOUNT_NAME         = local.loki_svc_account_name,
-        LOKI_SVC_ACCOUNT_IAM_ROLE_ARN = module.loki_service_account_role.arn,
+        LOKI_BUCKET_AWS_REGION                = data.aws_region.current.id,
+        LOKI_STORAGE_BUCKET_NAME              = aws_s3_bucket.loki_storage.id,
+        LOKI_STORAGE_BUCKET_SECRET_ACCESS_KEY = var.loki_storage_bucket_secret_access_key,
+        LOKI_STORAGE_BUCKET_ACCESS_KEY_ID     = var.loki_storage_bucket_access_key_id,
+        LOKI_STORAGE_CLASS_NAME               = var.loki_storage_class_name,
+        LOKI_SVC_ACCOUNT_NAME                 = local.loki_svc_account_name,
+        LOKI_SVC_ACCOUNT_IAM_ROLE_ARN         = local.loki_role_arn,
       }
     )
   ]
@@ -94,6 +104,10 @@ resource "kubernetes_config_map_v1" "loki_datasource" {
         uid: loki
         url: http://loki-gateway.${kubernetes_namespace_v1.monitoring.metadata[0].name}.svc.cluster.local
         access: proxy
+        jsonData:
+          httpHeaderName1: 'X-Scope-OrgID'
+        secureJsonData:
+          httpHeaderValue1: '1'
         EOT
   }
 }
@@ -108,27 +122,51 @@ resource "helm_release" "monitoring" {
   chart      = "kube-prometheus-stack"
   version    = var.kube_prometheus_version
   namespace  = kubernetes_namespace_v1.monitoring.metadata[0].name
+  # kps 83 upgrades roll Grafana + Prometheus + Alertmanager — the default 5
+  # min is too tight, especially on smaller non-EKS clusters.
+  timeout = 900
   values = [
     templatefile("${path.module}/assets/helm-values-monitoring.tpl",
       {
-        GRAFANA_PVC_SIZE                        = var.grafana_pvc_size,
-        GRAFANA_GATEWAY_NAME                    = var.grafana_gateway_parent_ref.name,
-        GRAFANA_GATEWAY_NAMESPACE               = var.grafana_gateway_parent_ref.namespace,
-        GRAFANA_GATEWAY_SECTION                 = var.grafana_gateway_parent_ref.section_name,
-        GRAFANA_HOST                            = var.grafana_host,
-        GRAFANA_ADMIN_USER                      = var.grafana_admin_user,
-        GRAFANA_ADMIN_PASSWORD                  = var.grafana_admin_password,
-        ALERT_MANAGER_GATEWAY_NAME              = var.alert_manager_gateway_parent_ref.name,
-        ALERT_MANAGER_GATEWAY_NAMESPACE         = var.alert_manager_gateway_parent_ref.namespace,
-        ALERT_MANAGER_GATEWAY_SECTION           = var.alert_manager_gateway_parent_ref.section_name,
-        ALERT_MANAGER_HOST                      = var.alert_manager_host,
-        ALERT_MANAGER_SLACK_WEBHOOK_URL         = var.alert_manager_slack_webhook_url,
-        ALERT_MANAGER_SLACK_WEBHOOK_URL_WEB_ENDPOINT_MONITORING = var.alert_manager_slack_webhook_url_web_endpoint_monitoring,
+        GRAFANA_PVC_SIZE                                        = var.grafana_pvc_size,
+        GRAFANA_PVC_STORAGE_CLASS                               = var.grafana_pvc_storage_class,
+        GRAFANA_GATEWAY_NAME                                    = var.grafana_gateway_parent_ref.name,
+        GRAFANA_GATEWAY_NAMESPACE                               = var.grafana_gateway_parent_ref.namespace,
+        GRAFANA_GATEWAY_SECTION                                 = var.grafana_gateway_parent_ref.section_name,
+        GRAFANA_HOST                                            = var.grafana_host,
+        GRAFANA_ADMIN_USER                                      = var.grafana_admin_user,
+        GRAFANA_ADMIN_PASSWORD                                  = var.grafana_admin_password,
+        GRAFANA_PLUGINS                                         = var.grafana_plugins,
+        GRAFANA_OAUTH_ENABLED                                   = var.grafana_oauth_enabled,
+        GRAFANA_OAUTH_NAME                                      = var.grafana_oauth_name,
+        GRAFANA_OAUTH_CLIENT_ID                                 = var.grafana_oauth_client_id,
+        GRAFANA_OAUTH_CLIENT_SECRET                             = var.grafana_oauth_client_secret,
+        GRAFANA_OAUTH_SCOPES                                    = var.grafana_oauth_scopes,
+        GRAFANA_OAUTH_AUTH_URL                                  = var.grafana_oauth_auth_url,
+        GRAFANA_OAUTH_TOKEN_URL                                 = var.grafana_oauth_token_url,
+        GRAFANA_OAUTH_API_URL                                   = var.grafana_oauth_api_url,
+        GRAFANA_OAUTH_ROLE_ATTRIBUTE_PATH                       = var.grafana_oauth_role_attribute_path,
+        GRAFANA_OAUTH_ROLE_ATTRIBUTE_STRICT                     = var.grafana_oauth_role_attribute_strict,
+        GRAFANA_OAUTH_USE_REFRESH_TOKEN                         = var.grafana_oauth_use_refresh_token,
+        GRAFANA_OAUTH_AUTO_LOGIN                                = var.grafana_oauth_auto_login,
+        GRAFANA_OAUTH_SKIP_ORG_ROLE_SYNC                        = var.grafana_oauth_skip_org_role_sync,
+        GRAFANA_AUTO_ASSIGN_ORG_ID                              = var.grafana_auto_assign_org_id,
+        ALERT_MANAGER_GATEWAY_NAME                              = var.alert_manager_gateway_parent_ref.name,
+        ALERT_MANAGER_GATEWAY_NAMESPACE                         = var.alert_manager_gateway_parent_ref.namespace,
+        ALERT_MANAGER_GATEWAY_SECTION                           = var.alert_manager_gateway_parent_ref.section_name,
+        ALERT_MANAGER_HOST                                      = var.alert_manager_host,
+        ALERT_MANAGER_SLACK_WEBHOOK_URL                         = var.alert_manager_slack_webhook_url,
+        ALERT_MANAGER_SLACK_WEBHOOK_URL_WEB_ENDPOINT_MONITORING = local.web_endpoint_monitoring_webhook,
+        GRAFANA_EXTRA_DASHBOARD_PROVIDERS                       = var.grafana_extra_dashboard_providers,
       }
     )
   ]
 }
 
+# Grafana Alloy — log shipper. Replaces promtail (which the project archived
+# in 2025). See
+# https://hodovi.cc/blog/kubernetes-events-monitoring-with-loki-alloy-and-grafana/
+# for the relabel-rules background.
 resource "helm_release" "grafana_alloy" {
   depends_on = [
     kubernetes_namespace_v1.monitoring,
@@ -139,7 +177,6 @@ resource "helm_release" "grafana_alloy" {
   chart      = "alloy"
   version    = "1.0.2"
   namespace  = kubernetes_namespace_v1.monitoring.metadata[0].name
-  # Values are based on https://hodovi.cc/blog/kubernetes-events-monitoring-with-loki-alloy-and-grafana/
   values = [
     <<-EOT
     controller:

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -41,6 +41,19 @@ resource "aws_iam_policy" "loki_storage_policy" {
   tags = var.aws_tags
 }
 
+# Pre-v0.19.0 these were declared without `count` (EKS-only module). Adding
+# the toggle for non-EKS clusters required `count`, so existing EKS callers
+# need `moved` blocks to avoid a destroy/create on the IAM role.
+moved {
+  from = aws_iam_policy.loki_storage_policy
+  to   = aws_iam_policy.loki_storage_policy[0]
+}
+
+moved {
+  from = module.loki_service_account_role
+  to   = module.loki_service_account_role[0]
+}
+
 module "loki_service_account_role" {
   count   = local.is_eks ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -1,3 +1,9 @@
+variable "target_cluster" {
+  description = "Target cluster type. 'eks' uses IRSA for Loki bucket access; any other value provisions Loki with static AWS credentials and a PVC-backed storage class."
+  type        = string
+  default     = "eks"
+}
+
 variable "target_namespace" {
   type        = string
   description = "The namespace where the monitoring stack will be deployed."
@@ -19,6 +25,26 @@ variable "loki_storage_bucket_name" {
   description = "The name of the S3 bucket where Loki will store logs. This bucket will be created by Terraform."
 }
 
+variable "loki_storage_bucket_secret_access_key" {
+  type        = string
+  description = "Secret access key for the S3 bucket where Loki stores logs. Used only when target_cluster != \"eks\"; EKS deployments authenticate via IRSA."
+  sensitive   = true
+  default     = ""
+}
+
+variable "loki_storage_bucket_access_key_id" {
+  type        = string
+  description = "Access key ID for the S3 bucket where Loki stores logs. Used only when target_cluster != \"eks\"; EKS deployments authenticate via IRSA."
+  sensitive   = true
+  default     = ""
+}
+
+variable "loki_storage_class_name" {
+  type        = string
+  description = "StorageClass for Loki PVCs (read/write/backend persistence). Only used when target_cluster != \"eks\"."
+  default     = "gp2"
+}
+
 variable "aws_tags" {
   type        = map(string)
   description = "Tags to apply to AWS resources. S3 bucket for Loki storage and IAM role for Loki service account."
@@ -26,9 +52,11 @@ variable "aws_tags" {
     "ManagedBy" = "Terraform"
   }
 }
+
 variable "oidc_provider_arn" {
   type        = string
-  description = "The ARN of the OIDC provider for the EKS cluster. Will be used to define Loki service-account access to the storage S3 bucket."
+  description = "ARN of the OIDC provider for the EKS cluster (IRSA for the Loki service account). Leave empty for non-EKS deployments."
+  default     = ""
 }
 
 variable "grafana_admin_user" {
@@ -39,10 +67,18 @@ variable "grafana_admin_user" {
 variable "grafana_admin_password" {
   type        = string
   description = "The admin password for Grafana."
+  sensitive   = true
 }
+
 variable "grafana_pvc_size" {
-  description = "The size of the Grafana Persistent Volume Claim"
+  description = "The size of the Grafana Persistent Volume Claim."
   type        = string
+}
+
+variable "grafana_pvc_storage_class" {
+  description = "StorageClass for the Grafana PVC. Leave empty to use the cluster's default StorageClass."
+  type        = string
+  default     = ""
 }
 
 variable "grafana_gateway_parent_ref" {
@@ -62,35 +98,139 @@ variable "alert_manager_gateway_parent_ref" {
     section_name = string
   })
 }
+
 variable "alert_manager_host" {
   description = "The host for Alert Manager"
   type        = string
 }
+
 variable "alert_manager_slack_webhook_url" {
   description = "The Slack Webhook URL for Alert Manager"
   type        = string
   sensitive   = true
 }
+
 variable "alert_manager_slack_webhook_url_web_endpoint_monitoring" {
-  description = "The Slack Webhook URL for the Web Endpoint monitoring (blackbox exporter)"
+  description = "Slack Webhook URL for the Web Endpoint monitoring (blackbox exporter). Falls back to alert_manager_slack_webhook_url when empty."
   type        = string
   sensitive   = true
+  default     = ""
 }
+
 variable "grafana_host" {
   description = "The host for Grafana"
   type        = string
 }
-variable "promtail_version" {
-  type        = string
-  description = "Promtail version."
-}
+
 variable "blackbox_exporter_version" {
   type        = string
   description = "Blackbox exporter version."
   default     = "9.0.0"
 }
+
 variable "blackbox_exporter" {
   description = "Whether to install the Blackbox Exporter"
   type        = bool
   default     = true
+}
+
+variable "grafana_plugins" {
+  description = "List of Grafana plugins to install."
+  type        = list(string)
+  default     = []
+}
+
+variable "grafana_oauth_enabled" {
+  description = "Enable OAuth authentication for Grafana."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_oauth_name" {
+  description = "Display name for the OAuth provider (shown on the Grafana login page)."
+  type        = string
+  default     = "OAuth"
+}
+
+variable "grafana_oauth_client_id" {
+  description = "OAuth client ID."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_oauth_client_secret" {
+  description = "OAuth client secret."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "grafana_oauth_scopes" {
+  description = "OAuth scopes (space-separated)."
+  type        = string
+  default     = "openid email profile"
+}
+
+variable "grafana_oauth_auth_url" {
+  description = "OAuth authorization URL."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_oauth_token_url" {
+  description = "OAuth token URL."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_oauth_api_url" {
+  description = "OAuth API / userinfo URL."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_oauth_role_attribute_path" {
+  description = "JMESPath expression used to resolve the Grafana role from the OAuth userinfo response."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_oauth_role_attribute_strict" {
+  description = "If true, deny login when the Grafana role cannot be extracted via role_attribute_path."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_oauth_use_refresh_token" {
+  description = "Enable refresh token usage for OAuth."
+  type        = bool
+  default     = true
+}
+
+variable "grafana_oauth_auto_login" {
+  description = "Skip the Grafana login page and redirect directly to the OAuth provider."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_oauth_skip_org_role_sync" {
+  description = "Skip syncing org roles from the OAuth provider on login (preserves manual org assignments)."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_auto_assign_org_id" {
+  description = "Default org ID for new OAuth users. 0 falls back to Grafana's default org (1)."
+  type        = number
+  default     = 0
+}
+
+variable "grafana_extra_dashboard_providers" {
+  description = "Additional dashboard providers for multi-org support. Each entry mounts a ConfigMap at /var/lib/grafana/dashboards/<name> and provisions into the specified org."
+  type = list(object({
+    name           = string
+    org_id         = number
+    configmap_name = string
+  }))
+  default = []
 }


### PR DESCRIPTION
## Summary

Promotes the features that had lived in the OTC `temp-monitoring` fork ([project-ops Contiamo/otc-cce-cluster/temp-monitoring](https://github.com/contiamo/project-ops/tree/main/Contiamo/otc-cce-cluster/temp-monitoring)) into the shared monitoring module so the OTC workspace can switch over and `temp-monitoring/` can be deleted (Stage 2b of CON-2421).

### New surface area

- `target_cluster` toggle — `eks` (default) keeps the current IRSA flow; anything else skips IAM + IRSA and uses static AWS credentials for Loki + PVC-backed Loki storage.
- Grafana OAuth (generic_oauth): 11 new variables, disabled by default.
- Grafana plugins list.
- Grafana multi-org dashboard providers — additional ConfigMaps mounted and provisioned into non-default orgs.
- `grafana_pvc_storage_class` (defaults to `""` = cluster-default).

### Fixes / improvements

- `deploymentStrategy: Recreate` for Grafana → no more Multi-Attach errors on RWO PVC upgrades.
- `helm_release.monitoring.timeout` → 900s. Default 300s was too tight for kps 83 rolling Grafana + Prometheus + Alertmanager in one go.
- `crds.upgradeJob.enabled` nesting fixed (was `upgradeJob:` at the top level, which 83.x ignores — this is what bit us on the OTC Stage 1 apply).
- Loki datasource ConfigMap now sets `X-Scope-OrgID: 1` so multi-tenant and single-tenant installs behave identically.
- Drop the unused `promtail_version` var (alloy superseded promtail in a prior release).

### Existing callers

Nothing should break: every new variable has a default, and the one default that changed (`persistence.enabled: false → true`) was previously unreachable because `grafana_pvc_size` has no default — everyone was already passing a size. The storage class defaults to `""` which uses the cluster-default class.

Refs: CON-2421

## Test plan

- [x] `tofu validate` for both EKS-shaped and OTC-shaped module calls
- [x] `templatefile()` renders both value files into parseable YAML with all expected top-level keys
- [x] OAuth + plugins + multi-org blocks render correctly when enabled
- [ ] Stage 2b: OTC workspace switches from `./temp-monitoring` to `?ref=v0.19.0` and plan shows only `moved` blocks, zero destroys