### PR TITLE
fix(monitoring): disable KubeProxyDown alert

### DIFF
--- a/monitoring/assets/helm-values-monitoring.tpl
+++ b/monitoring/assets/helm-values-monitoring.tpl
@@ -126,6 +126,7 @@ defaultRules:
     AlertmanagerFailedToSendAlerts: true
     CPUThrottlingHigh: true
     KubeletTooManyPods: true
+    KubeProxyDown: true
 
 alertmanager:
   ingress:


### PR DESCRIPTION
## Summary

- Adds `KubeProxyDown: true` to the `defaultRules.disabled` section in the kube-prometheus-stack Helm values template
- `kube-proxy` is not used on CCE/OTC clusters (Cilium handles networking), so this alert permanently fires as a false-positive

## Test plan

- [ ] Verify alert no longer fires after `terraform apply` on a cluster using this module
- [ ] Confirm other kube-proxy-related scrape configs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)