### PR TITLE
fix(ci): sort releases by semver, not publication date

### DIFF
--- a/.github/workflows/update-envoy-gateway-crds.yaml
+++ b/.github/workflows/update-envoy-gateway-crds.yaml
@@ -16,8 +16,12 @@ jobs:
       - name: Get latest stable Envoy Gateway release
         id: latest
         run: |
+          # Sort by semantic version, not publication date — a patch on an
+          # older minor line can be published after a newer minor release
+          # (e.g. v1.6.7 backported after v1.7.2 already exists).
           VERSION=$(gh api repos/envoyproxy/gateway/releases \
-            --jq '[.[] | select(.prerelease == false and .draft == false)][0].tag_name')
+            --jq '.[] | select(.prerelease == false and .draft == false) | .tag_name' \
+            | sort -V | tail -n1)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Latest stable release: ${VERSION}"
         env:

--- a/.github/workflows/update-gateway-api-crds.yaml
+++ b/.github/workflows/update-gateway-api-crds.yaml
@@ -16,8 +16,11 @@ jobs:
       - name: Get latest stable Gateway API release
         id: latest
         run: |
+          # Sort by semantic version, not publication date — a patch on an
+          # older minor line can be published after a newer minor release.
           VERSION=$(gh api repos/kubernetes-sigs/gateway-api/releases \
-            --jq '[.[] | select(.prerelease == false and .draft == false)][0].tag_name')
+            --jq '.[] | select(.prerelease == false and .draft == false) | .tag_name' \
+            | sort -V | tail -n1)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Latest stable release: ${VERSION}"
         env:

--- a/.github/workflows/update-onepassword-connect-crds.yaml
+++ b/.github/workflows/update-onepassword-connect-crds.yaml
@@ -18,11 +18,13 @@ jobs:
         run: |
           # Release tags in 1Password/connect-helm-charts are prefixed with
           # the chart name (e.g. `connect-2.4.1`, `secrets-injector-1.2.0`)
-          # because the repo ships multiple charts. We want the newest
-          # non-prerelease `connect-*` tag, then strip the prefix.
+          # because the repo ships multiple charts. Filter for `connect-*`,
+          # strip the prefix, then pick the highest semantic version — the
+          # API returns releases by publication date, so a backported patch
+          # on an older minor line could otherwise outrank the latest minor.
           VERSION=$(gh api repos/1Password/connect-helm-charts/releases \
-            --jq '[.[] | select(.prerelease == false and .draft == false) | .tag_name | select(startswith("connect-"))] | .[0]' \
-            | sed 's/^connect-//')
+            --jq '.[] | select(.prerelease == false and .draft == false) | .tag_name | select(startswith("connect-")) | sub("^connect-"; "")' \
+            | sort -V | tail -n1)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Latest stable release: ${VERSION}"
         env:


### PR DESCRIPTION
## Summary

The CRD update workflows fetched releases via the GitHub API and took the first element, which is the most recently *published* release — not the highest *semantic version*. A backported patch on an older minor line could therefore propose a downgrade.

This is what produced #57: envoy-gateway v1.6.7 was published on 2026-04-27 (after v1.7.2 on 2026-04-17), so the workflow picked v1.6.7 over v1.7.2.

```
v1.6.7  2026-04-27  ← previous logic picked this
v1.7.2  2026-04-17  ← actual latest (now picked)
```

## Fix

All three CRD workflows now:

1. Extract stable, non-prerelease/draft tag names.
2. Sort with `sort -V`.
3. Take the last (highest) entry.

For onepassword-connect the `connect-` chart prefix is stripped in jq via `sub()` so the sort sees clean semvers.

## Verification (local)

```
$ gh api repos/envoyproxy/gateway/releases --jq '.[] | select(.prerelease==false and .draft==false) | .tag_name' | sort -V | tail -n1
v1.7.2
$ gh api repos/kubernetes-sigs/gateway-api/releases --jq '.[] | select(.prerelease==false and .draft==false) | .tag_name' | sort -V | tail -n1
v1.5.1
$ gh api repos/1Password/connect-helm-charts/releases --jq '.[] | select(.prerelease==false and .draft==false) | .tag_name | select(startswith("connect-")) | sub("^connect-"; "")' | sort -V | tail -n1
2.4.1
```

## Follow-up

PR #57 will be closed; once this lands the next scheduled run (or a manual `workflow_dispatch`) will open a clean envoy-gateway v1.7.2 PR.