### PR TITLE
fix(ecr-pull-helper): drop kubernetes provider version pin

### DIFF
--- a/ecr-pull-helper/providers.tf
+++ b/ecr-pull-helper/providers.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      source = "hashicorp/kubernetes"
     }
   }
 }


### PR DESCRIPTION
## Summary

Removes \`version = \"~> 2.0\"\` from the \`ecr-pull-helper\` module's \`required_providers\`. Caller workspaces now control their own kubernetes provider version unconstrained by this module.

## Why

Renovate is trying to bump the Brax jupyter-hub workspace to \`kubernetes = \"~> 3.0\"\`, but \`ecr-pull-helper\` (consumed by that workspace) declares \`~> 2.0\`. OpenTofu intersects the two constraints → empty set → \`tofu init\` fails:

\`\`\`
Error: Failed to resolve provider packages
Could not resolve provider hashicorp/kubernetes: no available releases
match the given constraints ~> 2.0, ~> 3.0
\`\`\`

The same blocker hits \`Contiamo/eks-cluster\` and \`Contiamo/otc-cce-cluster\` (also via \`ecr-pull-helper\`).

## Compatibility check

The module only uses stable v1-suffixed kubernetes resources:

- \`kubernetes_namespace_v1\`
- \`kubernetes_secret_v1\`
- \`kubernetes_service_account_v1\`
- \`kubernetes_cluster_role_v1\`
- \`kubernetes_cluster_role_binding_v1\`
- (plus a CronJob/Job)

These were stable across kubernetes provider 2.x → 3.x. No internal use of the deprecated config_paths / load_config_file fields that 3.x cleaned up.

## Trade-off

Removing the version field means the module no longer documents which provider versions it's been tested against. For a small low-churn module like this one, the operational simplicity (never re-bump constraint when a major lands) is worth more than that documentation.

## Effect on consumers

\`ecr-pull-helper\` is consumed via unpinned \`?ref=\` in both \`Brax/brax-jupyter-hub\` and \`Contiamo/otc-cce-cluster\` — they track the default branch. Once this lands and release-please cuts a new tag, both will pick up the fix on next \`tofu init\` automatically.

## Test plan

- [ ] Merge → release-please cuts a new tag
- [ ] Re-run Scalr on project-ops PR #786 (Brax) — \`tofu init\` should succeed
- [ ] Re-run Scalr on project-ops PRs #788 (EKS) and #789 (OTC) — verify same root cause and same fix