### PR TITLE
docs: align READMEs with per-module release model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,63 @@
-# Terraform
-Contains Terraform modules.
-## Usage
+# Contiamo Terraform Modules
 
-- Modules stored in this repo can be referenced in other projects:
-    ```terraform
-    module "slack" {
-        source = "git@github.com:contiamo/terraform.git//slack"
-        channel_name = "[your value]"
-        ...
-    }
-    ```
-    It is also possible to pin a module version:
+A monorepo of reusable Terraform modules maintained by Contiamo. Each top-level directory is an independently-versioned module — see the auto-generated wiki for the full reference of every module.
 
-    ```terraform
-    module "slack" {
-        source = "git@github.com:contiamo/terraform.git//slack?ref=tags/v0.1.0"
-        channel_name = "[your value]"
-        ...
-    }
-    ```
-- Refer to individual module docs for examples.
+> 📚 **[Browse all modules in the wiki →](https://github.com/contiamo/terraform/wiki)**
+>
+> The wiki is the canonical source of truth: it lists every module with its latest tag, an auto-generated input/output table, a usage example pinned to the current version, and a per-module changelog. Updated automatically on every release.
 
+## Referencing a module
 
+Each module has its own tag of the form `<module>/v<X.Y.Z>` (e.g. `slack/v1.4.0`). To consume a module from another Terraform project, pin the `ref` to a per-module tag:
+
+```hcl
+module "slack" {
+  source = "github.com/contiamo/terraform?ref=slack/v1.0.0"
+
+  channel_name = "..."
+}
+```
+
+Notes:
+
+- **Do not include a `//<module>` subdir** in the `source`. The published tag tree contains the module's files at the root, so go-getter would fail with `subdir "<module>" not found`.
+- The wiki shows the explicit `git::https://github.com/contiamo/terraform.git?ref=<module>/v<X.Y.Z>` form. Both formats are equivalent — the shorthand above is the same module fetched via the same tag.
+- For private access over SSH, swap the URL prefix: `git::ssh://git@github.com/contiamo/terraform.git?ref=<module>/v<X.Y.Z>`.
+
+## Available modules
+
+| Module | Purpose |
+|---|---|
+| [azure-openai](./azure-openai) | Azure OpenAI Cognitive Services with private endpoints |
+| [datahub](./datahub) | DataHub metadata platform deployment via Helm |
+| [ecr-pull-helper](./ecr-pull-helper) | ECR pull-through credential refresher for non-AWS clusters |
+| [elasticsearch](./elasticsearch) | Elasticsearch cluster setup |
+| [envoy-gateway](./envoy-gateway) | Envoy Gateway control plane + listener config |
+| [external-dns](./external-dns) | external-dns deployment |
+| [gateway-api-crds](./gateway-api-crds) | Kubernetes Gateway API CRD bundle |
+| [github](./github) | GitHub repository creation with Contiamo standard settings |
+| [langfuse](./langfuse) | Langfuse self-hosted deployment |
+| [monitoring](./monitoring) | Monitoring stack (Prometheus, Grafana, Loki, Alloy) |
+| [mwaa](./mwaa) | Amazon Managed Workflows for Apache Airflow |
+| [onepass](./onepass) | 1Password integration helpers |
+| [onepassword-connect](./onepassword-connect) | 1Password Connect operator deployment |
+| [onepassword-secret](./onepassword-secret) | Wraps `onepassword_item` data lookups for use in modules |
+| [slack](./slack) | Slack channel creation and user management |
+| [tailscale](./tailscale) | Tailscale operator + identity setup |
+| [whitesky](./whitesky) | Whitesky service configuration |
+
+## Release process
+
+Releases are fully automated by [techpivot/terraform-module-releaser](https://github.com/techpivot/terraform-module-releaser):
+
+- **The PR is the release.** Open a PR that touches one or more modules; the action posts a Release Plan comment listing exactly which modules will bump and to what version. On merge, tags and GitHub Releases are created within ~30 seconds.
+- **Conventional commits drive the bump.** `feat: …` → minor, `fix: …` / `chore: …` / `docs: …` → patch, `feat!: …` or a `BREAKING CHANGE:` footer → major. Use the conventional commit's `(scope)` if you like, but **module routing is by changed file paths**, not by scope — a commit only bumps the modules whose `.tf` files it touched.
+- **README, test, and docs changes don't trigger releases.** The action's `module-change-exclude-patterns` ignores `*.md`, `tests/**`, and `*.tftest.hcl` by default.
+- **Bundling multiple modules in one PR** bumps all of them in lockstep on merge — useful when a change cuts across modules.
+
+## Conventions
+
+- New modules go in a top-level directory named after the module.
+- Every module should have a `README.md` with a usage example pinned to the canonical source format above.
+- PR titles must follow the conventional commits format (enforced by the `Conventional commit titles / validate` workflow).
+- Code owners: `@contiamo/ops`.

--- a/azure-openai/README.md
+++ b/azure-openai/README.md
@@ -36,7 +36,7 @@ This fork includes breaking changes to align with Azure provider updates:
 
 ```hcl
 module "openai" {
-  source = "github.com/contiamo/terraform//azure-openai?ref=azure-openai/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=azure-openai/v1.0.0"
 
   resource_group_name = "my-resource-group"
   location            = "eastus"
@@ -59,7 +59,7 @@ module "openai" {
 
 ```hcl
 module "openai" {
-  source                         = "github.com/contiamo/terraform//azure-openai?ref=azure-openai/v1.0.0"
+  source                         = "github.com/contiamo/terraform?ref=azure-openai/v1.0.0"
   resource_group_name            = "my-resource-group"
   location                       = "eastus"
   account_name                   = "my-openai-account"

--- a/datahub/README.md
+++ b/datahub/README.md
@@ -12,7 +12,7 @@ The release will be installed into the cluster to which your kubectl config is c
 module "datahub" {
   # To reference as a private repo use "git@github.com:/contiamo...:
   # source = "git@github.com:contiamo/terraform.git//datahub"
-  source = "github.com/contiamo/terraform//datahub?ref=datahub/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=datahub/v1.0.0"
   datahub_namespace = "[your namespace]"
   ui_ingress_host = "[UI domain]"
   api_ingress_host = "[API domain]"

--- a/ecr-pull-helper/README.md
+++ b/ecr-pull-helper/README.md
@@ -7,7 +7,7 @@ This module  sets up a cronjob that keeps temporary Docker credentials for ECR u
 
 ```hcl
 module "ecr_helper" {
-  source = "github.com/contiamo/terraform//ecr-pull-helper?ref=ecr-pull-helper/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=ecr-pull-helper/v1.0.0"
 
   aws_secret_access_key       = [AWS secrets access key for a user with read-only ECR access]
   aws_access_key_id           = [AWS secret access key ID for a user with read-only ECR access]

--- a/envoy-gateway/README.md
+++ b/envoy-gateway/README.md
@@ -39,7 +39,7 @@ Deploys [Envoy Gateway](https://gateway.envoyproxy.io/) on Kubernetes with suppo
 
 ```hcl
 module "envoy_gateway" {
-  source = "github.com/contiamo/terraform//envoy-gateway?ref=envoy-gateway/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=envoy-gateway/v1.0.0"
 
   gateways = [{
     name = "envoy-public"
@@ -57,7 +57,7 @@ module "envoy_gateway" {
 
 ```hcl
 module "envoy_gateway" {
-  source = "github.com/contiamo/terraform//envoy-gateway?ref=envoy-gateway/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=envoy-gateway/v1.0.0"
 
 
   chart_version               = "v1.7.2"
@@ -99,7 +99,7 @@ module "envoy_gateway" {
 
 ```hcl
 module "envoy_gateway" {
-  source = "github.com/contiamo/terraform//envoy-gateway?ref=envoy-gateway/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=envoy-gateway/v1.0.0"
 
   cert_manager_cluster_issuer = "letsencrypt-production-dns01"
 

--- a/external-dns/README.md
+++ b/external-dns/README.md
@@ -16,7 +16,7 @@ This module is based on [this AWS community article](https://community.aws/tutor
 module "external_dns" {
   # To reference as a private repo use "git@github.com:/contiamo...:
   # source = "git@github.com:contiamo/terraform.git//external-dns"
-  source = "github.com/contiamo/terraform//external-dns?ref=external-dns/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=external-dns/v1.0.0"
   aws_region         = var.aws_region
   provider_arn       = [ Your EKS OIDC Provider ARN ]
   k8s_namespace      = "kube-system"

--- a/gateway-api-crds/README.md
+++ b/gateway-api-crds/README.md
@@ -6,7 +6,7 @@ Installs the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) CRDs usi
 
 ```hcl
 module "gateway_api_crds" {
-  source = "github.com/contiamo/terraform//gateway-api-crds?ref=gateway-api-crds/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=gateway-api-crds/v1.0.0"
 
   crd_version = "v1.5.1"
 }

--- a/github/README.md
+++ b/github/README.md
@@ -9,7 +9,7 @@ This module can be used to create Github repos with Contiamo's standard repo set
 module "github" {
     # To reference as a private repo use "git@github.com:/contiamo...:
     # source = "git@github.com:contiamo/terraform.git//github"
-    source = "github.com/contiamo/terraform//github?ref=github/v1.0.0"
+    source = "github.com/contiamo/terraform?ref=github/v1.0.0"
     repo_name = var.project_name
     repo_description = var.project_description
     repo_collaborators = local.users_to_add_as_github_collaborators

--- a/langfuse/README.md
+++ b/langfuse/README.md
@@ -33,7 +33,7 @@ The module deploys a complete Langfuse stack on Kubernetes including:
 module "langfuse" {
   # To reference as a private repo use "git@github.com:/contiamo...:
   # source = "git@github.com:contiamo/terraform.git//langfuse"
-  source = "github.com/contiamo/terraform//langfuse?ref=langfuse/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=langfuse/v1.0.0"
 
   langfuse_host          = "langfuse.example.com"
   admin_email            = "admin@example.com"
@@ -61,7 +61,7 @@ output "langfuse_access" {
 ```terraform
 # Deploy Langfuse
 module "langfuse" {
-  source = "github.com/contiamo/terraform//langfuse?ref=langfuse/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=langfuse/v1.0.0"
 
   langfuse_host          = "langfuse.mycompany.io"
   admin_email            = "platform@mycompany.io"

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -16,7 +16,7 @@ The stack assumes:
 
 ```hcl
 module "monitoring" {
-  source = "github.com/contiamo/terraform//monitoring?ref=monitoring/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=monitoring/v1.0.0"
 
   target_namespace        = "monitoring"
   kube_prometheus_version = "83.4.3"
@@ -53,7 +53,7 @@ module "monitoring" {
 
 ```hcl
 module "monitoring" {
-  source = "github.com/contiamo/terraform//monitoring?ref=monitoring/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=monitoring/v1.0.0"
 
   target_cluster                        = "otc"
   target_namespace                      = "monitoring"

--- a/onepassword-connect/README.md
+++ b/onepassword-connect/README.md
@@ -27,7 +27,7 @@ Deploys the [1Password Connect Helm chart](https://github.com/1Password/connect-
 
 ```hcl
 module "onepassword_connect" {
-  source = "github.com/contiamo/terraform//onepassword-connect?ref=onepassword-connect/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=onepassword-connect/v1.0.0"
 
   chart_version = "2.4.1"
   namespace     = "1password"
@@ -53,7 +53,7 @@ Use this when the cluster should read secrets from 1Password without running a C
 
 ```hcl
 module "onepassword_operator" {
-  source = "github.com/contiamo/terraform//onepassword-connect?ref=onepassword-connect/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=onepassword-connect/v1.0.0"
 
   chart_version = "2.4.1"
   namespace     = "1password"

--- a/onepassword-secret/README.md
+++ b/onepassword-secret/README.md
@@ -10,7 +10,7 @@ This module retrieves a secret field value from a 1Password item. It looks up a 
 module "onepassword_secret" {
     # To reference as a private repo use "git@github.com:/contiamo...:
     # source = "git@github.com:contiamo/terraform.git//onepassword-secret"
-    source = "github.com/contiamo/terraform//onepassword-secret?ref=onepassword-secret/v1.0.0"
+    source = "github.com/contiamo/terraform?ref=onepassword-secret/v1.0.0"
     vault_name = "My Vault"
     item_name  = "My Secret Item"
     field      = "password"

--- a/slack/README.md
+++ b/slack/README.md
@@ -9,7 +9,7 @@ This module creates a Slack channel and adds provided users (references by their
 module "slack" {
     # To reference as a private repo use "git@github.com:/contiamo...:
     # source = "git@github.com:contiamo/terraform.git//slack"
-    source = "github.com/contiamo/terraform//slack?ref=slack/v1.0.0"
+    source = "github.com/contiamo/terraform?ref=slack/v1.0.0"
     channel_name = "[new channel name]"
     channel_topic = "[new channel description]"
     channel_members = [list of user emails]

--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -10,7 +10,7 @@ This module installs a Tailscale Subnet Router for a K8S cluster
 module "tailscale" {
   # To reference as a private repo use "git@github.com:/contiamo...:
   # source = "git@github.com:contiamo/terraform.git//tailscale"
-  source = "github.com/contiamo/terraform//tailscale?ref=tailscale/v1.0.0"
+  source = "github.com/contiamo/terraform?ref=tailscale/v1.0.0"
   tailscale_auth_key = var.tailscale_auth_key
   create_tailscale_auth_key_secret = var.create_tailscale_auth_key_secret
   image_tag = "v1.54.1"


### PR DESCRIPTION
## Summary

Follow-up to #63. Two doc-only fixes:

- **Root `README.md`** rewritten for the new per-module release flow. Prominent link to the auto-generated [wiki](https://github.com/contiamo/terraform/wiki), canonical source format (without `//<module>` subdir), summary of how conventional commits drive bumps, and a table of all 17 modules.
- **Per-module READMEs**: example `source = …` lines updated to drop the `//<module>` subdir. The published tag tree contains each module's files at the root, so the subdir form fails with `subdir "<module>" not found` (we hit this in project-ops PR #806 and had to fix all references in a follow-up commit).

## Won't trigger any module releases

This PR only touches `*.md` files. The action's `module-change-exclude-patterns` defaults skip Markdown, so the Release Plan comment will list zero modules to bump.

## Test plan

- [ ] PR comment from the releaser shows "no modules to release"
- [ ] After merge, the wiki and the in-tree READMEs agree on the source format