### PR TITLE
fix(envoy-gateway): server-side apply for dashboards ConfigMap (256 KiB cap)

### DIFF
--- a/envoy-gateway/observability.tf
+++ b/envoy-gateway/observability.tf
@@ -12,6 +12,15 @@ locals {
 resource "kubectl_manifest" "grafana_dashboards" {
   count = var.enable_grafana_dashboards ? 1 : 0
 
+  # The 5 vendored dashboards total ~237 KB. Client-side apply (the kubectl
+  # provider's default) stores the entire object in the
+  # `kubectl.kubernetes.io/last-applied-configuration` annotation, blowing
+  # past the kube-apiserver's 256 KiB per-object annotation cap. Server-side
+  # apply records managed fields in `metadata.managedFields` instead, which
+  # has no such limit.
+  server_side_apply = true
+  force_conflicts   = true
+
   yaml_body = yamlencode({
     apiVersion = "v1"
     kind       = "ConfigMap"


### PR DESCRIPTION
## Problem

The Scalr apply for [project-ops f8bfe8b](https://github.com/contiamo/project-ops/commit/f8bfe8b) (envoy-gateway/v1.1.0 bump) failed:

```
ConfigMap "envoy-gateway-grafana-dashboards" is invalid:
metadata.annotations: Too long: may not be more than 262144 bytes
```

## Root cause

The 5 vendored dashboards total **~237 KB raw**. The kubectl provider's client-side apply (the default) stores the *entire rendered object* in `kubectl.kubernetes.io/last-applied-configuration` for drift detection, which lands in `metadata.annotations` and exceeds the kube-apiserver's hardcoded 256 KiB annotation cap.

## Fix

Flip the dashboards ConfigMap to server-side apply (`server_side_apply = true`). SSA records ownership in `metadata.managedFields`, which has no size limit. Same pattern already used by `kubectl_manifest.envoy_gateway_crds` in the same module.

`force_conflicts = true` ensures a re-apply cleanly overwrites a stale field manager (e.g. if someone ever installs the upstream `gateway-addons-helm` chart in parallel).

ServiceMonitor + PodMonitor are small (<2 KB) and stay on client-side apply.

## State of the world

EKS (and OTC) currently have:
- ✅ ServiceMonitor `envoy-gateway` — created
- ✅ PodMonitor `envoy-proxy` — created
- ❌ ConfigMap `envoy-gateway-grafana-dashboards` — apply failed

Once this lands and gets tagged as `envoy-gateway/v1.1.1`, a follow-up project-ops bump will retry the ConfigMap.

## Test plan

- [x] `tofu validate` clean
- [ ] Tag and bump consumers; Scalr apply on EKS + OTC creates the ConfigMap successfully; Grafana sidecar imports the 5 dashboards.