### PR TITLE
feat(envoy-gateway): expose allowed_listeners_from on per-Gateway config

### DIFF
--- a/envoy-gateway/README.md
+++ b/envoy-gateway/README.md
@@ -152,6 +152,7 @@ module "envoy_gateway" {
 | gateway_annotations | Extra annotations on the Gateway resource (merged with the cert-manager annotation) | `map(string)` | `{}` |
 | tls_secret_suffix | TLS secret suffix pattern | `string` | `"-tls-{idx}"` |
 | cert_manager_issuer | Override default issuer | `string` | null |
+| allowed_listeners_from | Which ListenerSets may attach to this Gateway (`spec.allowedListeners.namespaces.from`). One of `All`, `Same`, `None`. Default `All` so chart authors can ship ListenerSets in their own namespace. The Gateway API spec default is `None`. | `string` | `"All"` |
 
 ### Listener Object
 

--- a/envoy-gateway/main.tf
+++ b/envoy-gateway/main.tf
@@ -190,6 +190,17 @@ resource "kubectl_manifest" "gateway" {
     }
     spec = {
       gatewayClassName = each.key
+      # Controls which ListenerSets can attach to this Gateway. Defaults
+      # to "All" in our variable schema so chart authors can ship a
+      # ListenerSet in their app's own namespace and have it attach
+      # without explicit per-Gateway config from this module's caller.
+      # SNI hostname matching still applies, so a ListenerSet can't
+      # hijack an already-served hostname.
+      allowedListeners = {
+        namespaces = {
+          from = each.value.allowed_listeners_from
+        }
+      }
       listeners = concat(
         # HTTP listeners
         [

--- a/envoy-gateway/variables.tf
+++ b/envoy-gateway/variables.tf
@@ -102,10 +102,32 @@ variable "gateways" {
     gateway_annotations = optional(map(string), {}) # Extra annotations applied to the Gateway resource (merged with the cert-manager annotation)
     tls_secret_suffix   = optional(string)          # TLS secret suffix pattern (default: "-tls-{idx}")
     cert_manager_issuer = optional(string)          # Override default cert-manager issuer
+    # Which ListenerSets are allowed to attach to this Gateway. Maps to
+    # spec.allowedListeners.namespaces.from on the Gateway resource.
+    # Possible values:
+    #   * "All"  — ListenerSets in any namespace can attach (our default;
+    #              enables chart-author-owned ListenerSets that live in
+    #              the chart's own namespace).
+    #   * "Same" — only ListenerSets in envoy-gateway-system can attach.
+    #   * "None" — no ListenerSets attach; only listeners defined inline
+    #              on the Gateway are honoured. This is the Gateway API
+    #              spec default — flipped to "All" here because shipping
+    #              the cluster wildcard plus per-host ListenerSets is the
+    #              standard Contiamo pattern.
+    # SNI hostname matching still applies regardless of this setting, so a
+    # ListenerSet can't hijack an already-served hostname.
+    allowed_listeners_from = optional(string, "All")
   }))
 
   validation {
     condition     = length(var.gateways) > 0
     error_message = "At least one gateway must be configured."
+  }
+
+  validation {
+    condition = alltrue([
+      for g in var.gateways : contains(["All", "Same", "None"], g.allowed_listeners_from)
+    ])
+    error_message = "allowed_listeners_from must be one of: All, Same, None. (The Gateway API spec also defines Selector, but this module doesn't yet expose the selector field.)"
   }
 }


### PR DESCRIPTION
## Summary

Adds `spec.allowedListeners.namespaces.from` to the Gateway template, exposed per-Gateway as `allowed_listeners_from` (string).

- **Default**: `"All"` — chart authors can ship a ListenerSet in their app's own namespace and have it attach to the shared Gateway without any per-Gateway config change from the module caller. SNI hostname matching still applies, so a rogue ListenerSet can't hijack an already-served hostname.
- **Gateway API spec default is `"None"`** (closed). We override to `"All"` because the standard Contiamo pattern is now "shared Gateway with cluster wildcard + per-host ListenerSets owned by individual charts" (see [CON-2437](https://linear.app/contiamo/issue/CON-2437) and the corresponding pattern in [CLAUDE.md in project-ops](https://github.com/contiamo/project-ops/blob/main/CLAUDE.md#hostnames-outside-the-cluster-wildcard--use-listenersets)).
- Per-Gateway override available — set `allowed_listeners_from = "Same"` or `"None"` per Gateway.

## Why now

[CON-2437](https://linear.app/contiamo/issue/CON-2437) needs OTC's `envoy-public` Gateway to accept a ListenerSet that the swb-chatbot Helm chart deploys in the `stadtwerkebonn` namespace. Without this default flip, the module would emit no `allowedListeners` field → Kubernetes defaults to `from: None` → the ListenerSet stays `NotAccepted`.

This same default applies to EKS workspaces consuming the module — no current ListenerSets there today, so no immediate behavioural change, but future ListenerSets attach automatically.

## Validation

Module-level validation rejects unrecognised values with a clear error message. `Selector` is intentionally not exposed yet (would need to surface a label selector too — none of our current callers want it; can add later).

## Test plan

- [x] `tofu fmt` clean
- [ ] Caller (OTC) plan shows the Gateway being updated in-place to add `allowedListeners: { namespaces: { from: All } }`. No other diff.