### PR TITLE
fix(karpenter): restore closing bracket in locals.tf and fix update script

### DIFF
--- a/karpenter/locals.tf
+++ b/karpenter/locals.tf
@@ -11,7 +11,7 @@ locals {
   supported_versions = [
     "1.12.1",
     "1.12.0",
-  
+  ]
 
   # Karpenter v1 CRDs. Stable across versions on the v1.x line.
   crd_files = toset([

--- a/karpenter/scripts/update-karpenter.sh
+++ b/karpenter/scripts/update-karpenter.sh
@@ -87,7 +87,11 @@ items = [v.strip().strip('"') for v in m.group(1).split(',') if v.strip().strip(
 items.append("${VERSION}")
 items = sorted(set(items), key=lambda v: tuple(int(x) for x in v.split('.')), reverse=True)
 new_block = ',\n    '.join(f'"{v}"' for v in items)
-s = re.sub(r'(supported_versions\s*=\s*\[)(.*?)(\])', r'\1\n    ' + new_block + ',\n  \3', s, flags=re.DOTALL)
+# Build replacement carefully: the closing-bracket backreference must be
+# expressed as a raw string, otherwise '\3' is parsed as the octal escape
+# 0x03 (ETX) and the ']' is dropped, producing an invalid locals.tf.
+replacement = r'\1' + '\n    ' + new_block + ',\n  ' + r'\3'
+s = re.sub(r'(supported_versions\s*=\s*\[)(.*?)(\])', replacement, s, flags=re.DOTALL)
 p.write_text(s)
 PY
 


### PR DESCRIPTION
## Summary

- Restores the missing closing `]` of `supported_versions` in `karpenter/locals.tf` (currently a literal ETX 0x03 / `␃` — see line 14 of [03f74fe](https://github.com/contiamo/terraform/commit/03f74fe1ca97f7d422beb91d46a1180603aed0da)), which makes the module unparseable and breaks every downstream consumer (e.g. [project-ops#820](https://github.com/contiamo/project-ops/pull/820)).
- Fixes the root cause in `karpenter/scripts/update-karpenter.sh`: the `re.sub` replacement string concatenates a raw string with non-raw fragments, so `'\3'` is interpreted as the Python octal escape `\x03` (ETX) instead of "backreference to group 3" (the literal `]`). The script silently dropped the closing bracket on every run since.

## Root cause

```python
# before — '\3' is octal 0x03, not a backref
s = re.sub(r'(...)(.*?)(\])', r'\1\n    ' + new_block + ',\n  \3', s, ...)

# after — both backrefs expressed as raw strings
replacement = r'\1' + '\n    ' + new_block + ',\n  ' + r'\3'
s = re.sub(r'(...)(.*?)(\])', replacement, s, ...)
```

## Test plan

- [x] Locally simulated a hypothetical `1.13.0` bump against the fixed `locals.tf` using the fixed Python block — output has balanced brackets, no ETX, versions sorted descending.
- [ ] Tofu `init` on a project-ops branch that references this fix succeeds (will retest project-ops#820 once this merges).