### PR TITLE
feat(envoy-gateway): support ListenerSet-only Gateways

### DIFF
--- a/envoy-gateway/main.tf
+++ b/envoy-gateway/main.tf
@@ -182,9 +182,12 @@ resource "kubectl_manifest" "gateway" {
       name      = each.key
       namespace = var.namespace
       annotations = merge(
-        {
+        # Only request a cert-manager-issued cert when the caller has
+        # actually declared per-host listeners. In ListenerSet-only mode
+        # (listeners = []) each chart owns its own ListenerSet + cert.
+        length(each.value.listeners) > 0 ? {
           "cert-manager.io/cluster-issuer" = coalesce(each.value.cert_manager_issuer, var.cert_manager_cluster_issuer)
-        },
+        } : {},
         each.value.gateway_annotations,
       )
     }
@@ -201,7 +204,7 @@ resource "kubectl_manifest" "gateway" {
           from = each.value.allowed_listeners_from
         }
       }
-      listeners = concat(
+      listeners = length(each.value.listeners) > 0 ? concat(
         # HTTP listeners
         [
           for listener in each.value.listeners : {
@@ -233,14 +236,35 @@ resource "kubectl_manifest" "gateway" {
             }
           }
         ]
-      )
+        ) : [
+        # Anchor listener: the Gateway API CRD enforces listeners.minItems=1,
+        # so a ListenerSet-only Gateway still needs one inline listener.
+        # `anchor-http` is HTTP-only, port 80, no hostname filter — it acts
+        # as the landing point for ACME HTTP-01 challenges issued for hosts
+        # served by attached ListenerSets, and as a low-precedence catch-all
+        # for any traffic not matched by a ListenerSet's specific hostname.
+        {
+          name     = "anchor-http"
+          protocol = "HTTP"
+          port     = 80
+          allowedRoutes = {
+            namespaces = { from = "All" }
+          }
+        }
+      ]
     }
   })
 }
 
-# HTTPRoute for HTTPS redirect for each gateway
+# HTTPRoute for HTTPS redirect for each gateway. Skipped for
+# ListenerSet-only Gateways (no per-host listeners → nothing to redirect
+# at Gateway level; each app can ship its own HTTP->HTTPS HTTPRoute
+# alongside its ListenerSet if it wants the redirect behaviour).
 resource "kubectl_manifest" "httproute_redirect" {
-  for_each   = local.enabled_gateways
+  for_each = {
+    for gw_name, gw in local.enabled_gateways : gw_name => gw
+    if length(gw.listeners) > 0
+  }
   depends_on = [kubectl_manifest.gateway]
 
   yaml_body = yamlencode({

--- a/envoy-gateway/variables.tf
+++ b/envoy-gateway/variables.tf
@@ -93,15 +93,23 @@ variable "gateways" {
     name            = string               # Gateway name (e.g., "envoy-public")
     enabled         = optional(bool, true) # Whether to create this gateway
     envoyproxy_name = optional(string)     # Custom EnvoyProxy name (defaults to "{name}-proxy")
-    listeners = list(object({
+    # Per-host HTTP+HTTPS listener pairs to create on the Gateway. When
+    # empty (the default), the Gateway is created in "ListenerSet-only"
+    # mode: no per-host listeners, no cert-manager annotation, no
+    # HTTP->HTTPS redirect HTTPRoute, and a single placeholder HTTP
+    # listener (`anchor-http`, port 80, no hostname filter) is synthesised
+    # so the Gateway resource passes the Gateway API CRD's `listeners`
+    # minItems=1 check. Attach per-host listeners via ListenerSets owned
+    # by the consuming chart instead.
+    listeners = optional(list(object({
       domain          = string           # Domain pattern (e.g., "*.ctmo.io")
       name            = string           # Listener name suffix (e.g., "ctmo" -> "http-ctmo", "https-ctmo")
       tls_secret_name = optional(string) # Override the auto-generated TLS secret name. Use when reusing a Secret managed elsewhere (e.g. by an existing nginx Ingress) to avoid a fresh ACME issuance during cutover. If unset, the secret name is derived from `tls_secret_suffix`.
-    }))
-    lb_annotations      = map(string)               # LoadBalancer service annotations
-    gateway_annotations = optional(map(string), {}) # Extra annotations applied to the Gateway resource (merged with the cert-manager annotation)
-    tls_secret_suffix   = optional(string)          # TLS secret suffix pattern (default: "-tls-{idx}")
-    cert_manager_issuer = optional(string)          # Override default cert-manager issuer
+    })), [])
+    lb_annotations      = map(string)                       # LoadBalancer service annotations
+    gateway_annotations = optional(map(string), {})         # Extra annotations applied to the Gateway resource (merged with the cert-manager annotation when listeners is non-empty)
+    tls_secret_suffix   = optional(string, "-tls-{idx}")    # TLS secret suffix pattern. Only consumed when listeners is non-empty.
+    cert_manager_issuer = optional(string)                  # Override default cert-manager issuer
     # Which ListenerSets are allowed to attach to this Gateway. Maps to
     # spec.allowedListeners.namespaces.from on the Gateway resource.
     # Possible values:


### PR DESCRIPTION
## Summary

Allow the contiamo `envoy-gateway` module to create Gateways with **no inline per-host listeners** — i.e. the chart-author-owned ListenerSet pattern, all the way through.

When a caller passes `listeners = []` (or omits the field entirely) on a gateway entry, the module:

- **omits** the `cert-manager.io/cluster-issuer` annotation on the Gateway resource
- **synthesises** a single `anchor-http` listener (HTTP/80, no hostname filter) so the Gateway still satisfies the Gateway API CRD's `listeners.minItems = 1` constraint. The anchor doubles as the landing point for ACME HTTP-01 challenges issued for hosts served by attached ListenerSets, and as a low-precedence catch-all for unmatched traffic on port 80.
- **skips** creating the `httproute_redirect` HTTPRoute (no per-host HTTP listeners → nothing for it to redirect)

Each consuming chart is then expected to attach its own ListenerSet with per-host TLS listeners + HTTPRoutes, owning its own cert-manager Certificate.

`tls_secret_suffix` is also tightened — now a proper `optional(string, \"-tls-{idx}\")` instead of `optional(string)` with the default carried inline via `coalesce`. Identical effective behaviour.

## Backwards compatibility

Every existing caller (Contiamo EKS, OTC, dataplatform, etc.) passes a non-empty `listeners` list. The new empty-listeners branch never executes for them — Gateway YAML is bit-identical. Verified by reading their `envoy-gateway.tf` calls.

## First user

[contiamo/vonovia-voicebot](https://github.com/contiamo/vonovia-voicebot) — the new Vonovia CSVKI dev cluster wants to be ListenerSet-only from day one (no Gateway-level wildcard cert, every app brings its own ListenerSet). Already verified end-to-end against this branch via a local-path module source: `tofu apply` produces the expected diff and the resulting Gateway looks like:

```yaml
spec:
  listeners:
  - name: anchor-http
    port: 80
    protocol: HTTP
    allowedRoutes:
      namespaces:
        from: All
```

with no `cert-manager.io/cluster-issuer` annotation and no `httproute_redirect` HTTPRoute alongside.

## Suggested tag

`envoy-gateway/v1.5.0`

## Test plan

- [ ] Reviewer skims the diff for backwards-compat assumptions (the only condition split is on `length(listeners) > 0`).
- [ ] On merge + tag: bump the consuming repo's module ref and confirm `tofu plan` is a no-op for any cluster that passes a non-empty `listeners` list.