### PR TITLE
fix(envoy-gateway): avoid tuple-length mismatch in Gateway listeners ternary

### DIFF
--- a/envoy-gateway/main.tf
+++ b/envoy-gateway/main.tf
@@ -204,8 +204,14 @@ resource "kubectl_manifest" "gateway" {
           from = each.value.allowed_listeners_from
         }
       }
-      listeners = length(each.value.listeners) > 0 ? concat(
-        # HTTP listeners
+      # listeners is built as a single concat() of three arms so the
+      # result type is always list(object) regardless of the per-arm
+      # element count. Avoids a ternary whose two branches statically
+      # infer to tuples of different lengths — which Tofu 1.12+ rejects
+      # with "Inconsistent conditional result types" on clusters whose
+      # `listeners` is a statically-known 1-element list.
+      listeners = concat(
+        # HTTP listeners (empty when listeners=[])
         [
           for listener in each.value.listeners : {
             name     = "http-${listener.name}"
@@ -217,7 +223,7 @@ resource "kubectl_manifest" "gateway" {
             }
           }
         ],
-        # HTTPS listeners
+        # HTTPS listeners (empty when listeners=[])
         [
           for listener in each.value.listeners : {
             name     = "https-${listener.name}"
@@ -235,23 +241,28 @@ resource "kubectl_manifest" "gateway" {
               namespaces = { from = "All" }
             }
           }
-        ]
-        ) : [
-        # Anchor listener: the Gateway API CRD enforces listeners.minItems=1,
+        ],
+        # Anchor: synthesised only when no per-host listeners are
+        # declared. The Gateway API CRD enforces listeners.minItems=1,
         # so a ListenerSet-only Gateway still needs one inline listener.
-        # `anchor-http` is HTTP-only, port 80, no hostname filter — it acts
-        # as the landing point for ACME HTTP-01 challenges issued for hosts
-        # served by attached ListenerSets, and as a low-precedence catch-all
-        # for any traffic not matched by a ListenerSet's specific hostname.
-        {
-          name     = "anchor-http"
-          protocol = "HTTP"
-          port     = 80
-          allowedRoutes = {
-            namespaces = { from = "All" }
+        # `anchor-http` (HTTP/80, no hostname filter) doubles as the
+        # landing point for ACME HTTP-01 challenges issued for hosts
+        # served by attached ListenerSets, and as a low-precedence
+        # catch-all for traffic that isn't matched by a ListenerSet's
+        # specific hostname. range() is used to make the comprehension
+        # iterate 0 or 1 times — keeps the result a list(object)
+        # without tripping tofu's tuple-length type inference.
+        [
+          for _ in range(length(each.value.listeners) == 0 ? 1 : 0) : {
+            name     = "anchor-http"
+            protocol = "HTTP"
+            port     = 80
+            allowedRoutes = {
+              namespaces = { from = "All" }
+            }
           }
-        }
-      ]
+        ]
+      )
     }
   })
 }


### PR DESCRIPTION
## Summary

Hotfix for the v1.5.0 ListenerSet-only support — the ternary that picked between "HTTP + HTTPS listeners" and the synthesised "anchor-http only" produces tuples of different static lengths, which OpenTofu's stricter type checker rejects on any caller whose \`listeners\` is a statically-known 1-element list.

## Symptom

\`tofu plan\` on the existing **Contiamo EKS** and **OTC CCE** clusters fails immediately after bumping the module to v1.5.0:

\`\`\`
Error: Inconsistent conditional result types
  on .terraform/modules/envoy_gateway/main.tf line 207, in resource \"kubectl_manifest\" \"gateway\":
   207:       listeners = length(each.value.listeners) > 0 ? concat(
...
The true and false result expressions must have consistent types.
The 'true' tuple has length 2, but the 'false' tuple has length 1.
\`\`\`

The vonovia-voicebot caller (the first ListenerSet-only consumer) didn't hit this because its \`listeners = []\` comes from the variable's \`optional()\` default — Tofu types that as a list, not a tuple, which sidesteps the static-length inference.

## Fix

Drop the ternary. Build \`listeners\` as a single \`concat()\` of three for-comprehensions — HTTP, HTTPS, and the anchor — where the anchor arm uses \`range(length == 0 ? 1 : 0)\` so it iterates 0 or 1 times. The result is always \`list(object)\` and there's no tuple-length type to mismatch.

Effective output is unchanged:

| Caller's listeners | HTTP arm | HTTPS arm | Anchor arm | Resulting Gateway listeners |
|---|---|---|---|---|
| Non-empty | one per entry | one per entry | empty | HTTP + HTTPS pair per entry |
| Empty | empty | empty | one entry | single \`anchor-http\` |

## Verified

- \`tofu plan\` on **vonovia-voicebot** (listeners=[]) with this branch via a local path source: **No changes.** (Already on v1.5.0 in state with anchor-http; the fix produces identical output.)
- Awaiting a re-run of the EKS / OTC Scalr plans against this branch — should now plan cleanly instead of failing with the type error above.

## Suggested tag

\`envoy-gateway/v1.5.1\`