### PR TITLE
feat(envoy-gateway): topology spread constraints on Envoy proxy pods

### DIFF
--- a/envoy-gateway/README.md
+++ b/envoy-gateway/README.md
@@ -153,6 +153,35 @@ module "envoy_gateway" {
 | tls_secret_suffix | TLS secret suffix pattern | `string` | `"-tls-{idx}"` |
 | cert_manager_issuer | Override default issuer | `string` | null |
 | allowed_listeners_from | Which ListenerSets may attach to this Gateway (`spec.allowedListeners.namespaces.from`). One of `All`, `Same`, `None`. Default `All` so chart authors can ship ListenerSets in their own namespace. The Gateway API spec default is `None`. | `string` | `"All"` |
+| topology_spread_constraints | Pod topology spread constraints applied to the Envoy proxy pods for this gateway. Renders to `spec.provider.kubernetes.envoyDeployment.pod.topologySpreadConstraints` on the EnvoyProxy CR. See [Topology Spread Constraints](#topology-spread-constraints) below. | `list(object)` | strict zonal spread (see below) |
+
+#### Topology Spread Constraints
+
+The module default is a single strict zonal spread:
+
+```hcl
+topology_spread_constraints = [{
+  max_skew           = 1
+  topology_key       = "topology.kubernetes.io/zone"
+  when_unsatisfiable = "DoNotSchedule"
+  # label_selector auto-derived to match this gateway's pods
+}]
+```
+
+With the typical 2-replicas × 3-AZs Contiamo setup this guarantees each replica lands in a different AZ. The failure mode that prompted this field: both Envoy replicas landing in the same AZ during a node-churn, where the cluster's LB only served a subset of AZs — the same-AZ replica then wasn't registered as a target because its AZ wasn't enabled on the LB, and only one replica was carrying production traffic.
+
+`label_selector` is optional per constraint. When `null`, the module sets `matchLabels: { "gateway.envoyproxy.io/owning-gateway-name": "<gateway name>" }` so the constraint counts only pods belonging to this gateway — important when you have multiple gateways (e.g. `envoy-public` + `envoy-tailscale`) in the same namespace.
+
+Per-constraint fields:
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| max_skew | Maximum skew between domains | required |
+| topology_key | Node label to spread over (e.g. `topology.kubernetes.io/zone`) | required |
+| when_unsatisfiable | `DoNotSchedule` (strict, pod stays Pending) or `ScheduleAnyway` (soft hint) | required |
+| label_selector.match_labels | Override the auto-derived label selector | derived |
+
+Set `topology_spread_constraints = []` to opt out of spread entirely.
 
 ### Listener Object
 

--- a/envoy-gateway/main.tf
+++ b/envoy-gateway/main.tf
@@ -154,9 +154,31 @@ resource "kubectl_manifest" "envoyproxy" {
       provider = {
         type = "Kubernetes"
         kubernetes = {
-          envoyDeployment = {
-            replicas = var.replicas
-          }
+          envoyDeployment = merge(
+            { replicas = var.replicas },
+            length(each.value.topology_spread_constraints) > 0 ? {
+              pod = {
+                topologySpreadConstraints = [
+                  for tsc in each.value.topology_spread_constraints : {
+                    maxSkew           = tsc.max_skew
+                    topologyKey       = tsc.topology_key
+                    whenUnsatisfiable = tsc.when_unsatisfiable
+                    # Caller-supplied labelSelector wins; otherwise scope
+                    # the constraint to this gateway's pods so it doesn't
+                    # count proxies belonging to other gateways in the
+                    # same namespace.
+                    labelSelector = tsc.label_selector != null && try(tsc.label_selector.match_labels, null) != null ? {
+                      matchLabels = tsc.label_selector.match_labels
+                      } : {
+                      matchLabels = {
+                        "gateway.envoyproxy.io/owning-gateway-name" = each.key
+                      }
+                    }
+                  }
+                ]
+              }
+            } : {},
+          )
           envoyService = {
             type        = "LoadBalancer"
             annotations = each.value.lb_annotations

--- a/envoy-gateway/variables.tf
+++ b/envoy-gateway/variables.tf
@@ -106,10 +106,10 @@ variable "gateways" {
       name            = string           # Listener name suffix (e.g., "ctmo" -> "http-ctmo", "https-ctmo")
       tls_secret_name = optional(string) # Override the auto-generated TLS secret name. Use when reusing a Secret managed elsewhere (e.g. by an existing nginx Ingress) to avoid a fresh ACME issuance during cutover. If unset, the secret name is derived from `tls_secret_suffix`.
     })), [])
-    lb_annotations      = map(string)                       # LoadBalancer service annotations
-    gateway_annotations = optional(map(string), {})         # Extra annotations applied to the Gateway resource (merged with the cert-manager annotation when listeners is non-empty)
-    tls_secret_suffix   = optional(string, "-tls-{idx}")    # TLS secret suffix pattern. Only consumed when listeners is non-empty.
-    cert_manager_issuer = optional(string)                  # Override default cert-manager issuer
+    lb_annotations      = map(string)                    # LoadBalancer service annotations
+    gateway_annotations = optional(map(string), {})      # Extra annotations applied to the Gateway resource (merged with the cert-manager annotation when listeners is non-empty)
+    tls_secret_suffix   = optional(string, "-tls-{idx}") # TLS secret suffix pattern. Only consumed when listeners is non-empty.
+    cert_manager_issuer = optional(string)               # Override default cert-manager issuer
     # Which ListenerSets are allowed to attach to this Gateway. Maps to
     # spec.allowedListeners.namespaces.from on the Gateway resource.
     # Possible values:
@@ -125,6 +125,38 @@ variable "gateways" {
     # SNI hostname matching still applies regardless of this setting, so a
     # ListenerSet can't hijack an already-served hostname.
     allowed_listeners_from = optional(string, "All")
+    # Pod topology spread constraints applied to the Envoy proxy pods for
+    # this gateway. Renders to
+    # `spec.provider.kubernetes.envoyDeployment.pod.topologySpreadConstraints`
+    # on the EnvoyProxy CR.
+    #
+    # The module default is a single strict zonal spread (maxSkew=1,
+    # topologyKey=topology.kubernetes.io/zone, whenUnsatisfiable=
+    # DoNotSchedule). With the typical 2-replicas-across-3-AZs Contiamo
+    # setup this guarantees each replica lands in a different AZ — the
+    # failure mode that prompted this field was both Envoy replicas
+    # landing in the same AZ during a node-churn, where the cluster's LB
+    # only served a subset of AZs and the same-AZ replica was the one
+    # not registered as a target. Set to `[]` to disable spread entirely.
+    #
+    # `label_selector` is optional: when null, defaults to
+    # `gateway.envoyproxy.io/owning-gateway-name = <gateway name>` so the
+    # constraint only counts pods belonging to this gateway and doesn't
+    # interact with other gateways' proxies in the same namespace.
+    topology_spread_constraints = optional(list(object({
+      max_skew           = number
+      topology_key       = string # e.g. "topology.kubernetes.io/zone"
+      when_unsatisfiable = string # "DoNotSchedule" or "ScheduleAnyway"
+      label_selector = optional(object({
+        match_labels = optional(map(string))
+      }))
+      })), [
+      {
+        max_skew           = 1
+        topology_key       = "topology.kubernetes.io/zone"
+        when_unsatisfiable = "DoNotSchedule"
+      }
+    ])
   }))
 
   validation {
@@ -137,5 +169,15 @@ variable "gateways" {
       for g in var.gateways : contains(["All", "Same", "None"], g.allowed_listeners_from)
     ])
     error_message = "allowed_listeners_from must be one of: All, Same, None. (The Gateway API spec also defines Selector, but this module doesn't yet expose the selector field.)"
+  }
+
+  validation {
+    condition = alltrue([
+      for g in var.gateways : alltrue([
+        for tsc in g.topology_spread_constraints :
+        contains(["DoNotSchedule", "ScheduleAnyway"], tsc.when_unsatisfiable)
+      ])
+    ])
+    error_message = "topology_spread_constraints[*].when_unsatisfiable must be one of: DoNotSchedule, ScheduleAnyway."
   }
 }


### PR DESCRIPTION
## Summary

- Adds `topology_spread_constraints` per gateway, plumbed through to `spec.provider.kubernetes.envoyDeployment.pod.topologySpreadConstraints` on the EnvoyProxy CR.
- Module default: a single strict zonal spread (`maxSkew=1, topologyKey=topology.kubernetes.io/zone, whenUnsatisfiable=DoNotSchedule`).
- When `label_selector` is omitted, defaults to `gateway.envoyproxy.io/owning-gateway-name = <gateway-name>` so a multi-gateway namespace doesn't have the constraints fighting each other.

## Why

On Contiamo EKS yesterday, both `envoy-public` replicas landed in `eu-central-1c` during a Karpenter-driven node churn. The cluster's public NLB was only serving 1a + 1b (the public subnet in 1c was missing `kubernetes.io/role/elb`), so both replicas were marked `Target.NotInUse` and the public Gateway dropped TLS until a manual pod delete forced a reschedule into a served AZ.

The subnet-tag root cause was fixed out-of-band, but the module had no defence against this class of failure: with no spread constraint the scheduler is free to co-locate Envoy replicas, and a single-AZ failure (LB-served or otherwise) takes the Gateway down even when all subnets are correctly tagged.

## Default rationale

`DoNotSchedule` rather than `ScheduleAnyway` because the soft variant would not have prevented the original incident. With the standard Contiamo 2-replicas × 3-AZs setup there is no downside — skew stays at zero. Callers with unusual topologies override the field; `topology_spread_constraints = []` opts out entirely.

## Behaviour change

All existing consumers gain the default TSC on the next plan. Expected diff on the EnvoyProxy CR's `yaml_body` only (no pod restart needed; the EnvoyProxy controller will roll the deployment if the resulting Deployment spec changes, which it does — pods will be re-spread on the next reconcile if they're currently mis-spread).

## Test plan

- [ ] Module validates locally (`tofu validate` against a smoke-test caller — passes)
- [ ] Plan on `project-ops/Contiamo/eks-cluster` with the bumped ref shows only the expected `kubectl_manifest.envoy_gateway*.envoyproxy[*]` update
- [ ] Apply on EKS; confirm the two `envoy-public` pods stay across distinct AZs (and pick up the strict constraint on next reschedule)
- [ ] Same for OTC CCE on the follow-up bump