### PR TITLE
feat(envoy-gateway): document topology spread override patterns

### DIFF
--- a/envoy-gateway/README.md
+++ b/envoy-gateway/README.md
@@ -183,6 +183,29 @@ Per-constraint fields:
 
 Set `topology_spread_constraints = []` to opt out of spread entirely.
 
+Override example — soften to a hint plus add a per-node spread on top of the per-zone one:
+
+```hcl
+gateways = [
+  {
+    name = "envoy-public"
+    # ...
+    topology_spread_constraints = [
+      {
+        max_skew           = 1
+        topology_key       = "topology.kubernetes.io/zone"
+        when_unsatisfiable = "ScheduleAnyway"   # relax from default DoNotSchedule
+      },
+      {
+        max_skew           = 1
+        topology_key       = "kubernetes.io/hostname"
+        when_unsatisfiable = "ScheduleAnyway"
+      },
+    ]
+  },
+]
+```
+
 ### Listener Object
 
 | Field | Description | Default |


### PR DESCRIPTION
## Summary

Adds a worked override example to the README's Topology Spread Constraints section:

- How to relax the strict `DoNotSchedule` default to `ScheduleAnyway`.
- How to stack a per-node spread on top of the per-zone one.

The constraint shape from #78 is already documented; this just fills in the most common override patterns.

## Secondary purpose

This PR also re-fires the `Terraform Module Releaser` workflow.

The merge close event for #78 was lost (every prior merged PR has a paired close-event releaser run within ~3 seconds of merge; #78 has none). As a result `envoy-gateway/v1.6.0` was never cut — last tag is still `envoy-gateway/v1.5.1`. Merging this PR will fire the releaser on close, and since the releaser analyses commits since the last module tag, both #78's `feat:` commit and this PR's `feat:` commit will roll into a single `envoy-gateway/v1.6.0` release.

If we see the same close-event loss pattern again on this PR, we'll need to manually tag — but the lost event seems to have been a one-off so I'd rather try the automation path once.

## Test plan

- [ ] Merge fires a `Terraform Module Releaser` workflow run within seconds.
- [ ] `envoy-gateway/v1.6.0` tag and GitHub release are created.
- [ ] Release notes mention both #78 (TSC support) and this PR (docs).